### PR TITLE
Fix auth exceptions

### DIFF
--- a/docs/FacebookResponseException.fbmd
+++ b/docs/FacebookResponseException.fbmd
@@ -9,9 +9,9 @@ Represents an exception thrown by executing a Facebook request.
 
 This base class has several subclasses:
 
-`FacebookAuthorizationException`  
+`FacebookAuthenticationException`  
 `FacebookClientException`  
-`FacebookPermissionException`  
+`FacebookAuthorizationException`  
 `FacebookServerException`  
 `FacebookThrottleException`  
 `FacebookOtherException`  

--- a/docs/sdk_reference.fbmd
+++ b/docs/sdk_reference.fbmd
@@ -73,8 +73,12 @@ FB(devsite:markdown-wiki:table {
   columns: ['Class name','Description',],
   rows: [
     [
+      '`[Facebook\Exceptions\FacebookAuthenticationException](/docs/php/FacebookAuthenticationException)`',
+      'Thrown when Graph returns an authentication error.',
+    ],
+    [
       '`[Facebook\Exceptions\FacebookAuthorizationException](/docs/php/FacebookAuthorizationException)`',
-      'Thrown when Graph returns an authorization error.',
+      'Thrown when Graph returns a user permissions error.',
     ],
     [
       '`[Facebook\Exceptions\FacebookClientException](/docs/php/FacebookClientException)`',
@@ -83,10 +87,6 @@ FB(devsite:markdown-wiki:table {
     [
       '`[Facebook\Exceptions\FacebookOtherException](/docs/php/FacebookOtherException)`',
       'Thrown when Graph returns an error that is unknown to the SDK.',
-    ],
-    [
-      '`[Facebook\Exceptions\FacebookPermissionException](/docs/php/FacebookPermissionException)`',
-      'Thrown when Graph returns a user permissions error.',
     ],
     [
       '`[Facebook\Exceptions\FacebookResponseException](/docs/php/FacebookResponseException)`',

--- a/src/Facebook/Exceptions/FacebookAuthenticationException.php
+++ b/src/Facebook/Exceptions/FacebookAuthenticationException.php
@@ -24,10 +24,10 @@
 namespace Facebook\Exceptions;
 
 /**
- * Class FacebookPermissionException
+ * Class FacebookAuthenticationException
  * @package Facebook
  */
-class FacebookPermissionException extends FacebookSDKException
+class FacebookAuthenticationException extends FacebookSDKException
 {
 
 }

--- a/src/Facebook/Exceptions/FacebookResponseException.php
+++ b/src/Facebook/Exceptions/FacebookResponseException.php
@@ -89,7 +89,7 @@ class FacebookResponseException extends FacebookSDKException
         case 463:
         case 464:
         case 467:
-          return new static($response, new FacebookAuthorizationException($message, $code));
+          return new static($response, new FacebookAuthenticationException($message, $code));
           break;
       }
     }
@@ -99,7 +99,7 @@ class FacebookResponseException extends FacebookSDKException
       case 100:
       case 102:
       case 190:
-        return new static($response, new FacebookAuthorizationException($message, $code));
+        return new static($response, new FacebookAuthenticationException($message, $code));
         break;
 
       // Server issue, possible downtime
@@ -123,13 +123,13 @@ class FacebookResponseException extends FacebookSDKException
 
     // Missing Permissions
     if ($code == 10 || ($code >= 200 && $code <= 299)) {
-      return new static($response, new FacebookPermissionException($message, $code));
+      return new static($response, new FacebookAuthorizationException($message, $code));
     }
 
     // OAuth authentication error
     if (isset($data['error']['type'])
-      and $data['error']['type'] === 'OAuthException') {
-      return new static($response, new FacebookAuthorizationException($message, $code));
+      && $data['error']['type'] === 'OAuthException') {
+      return new static($response, new FacebookAuthenticationException($message, $code));
     }
 
     // All others

--- a/tests/Exceptions/FacebookResponseExceptionTest.php
+++ b/tests/Exceptions/FacebookResponseExceptionTest.php
@@ -41,7 +41,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     $this->request = new FacebookRequest(new FacebookApp('123', 'foo'));
   }
 
-  public function testAuthorizationExceptions()
+  public function testAuthenticationExceptions()
   {
     $params = [
       'error' => [
@@ -54,7 +54,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
 
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(100, $exception->getCode());
     $this->assertEquals(0, $exception->getSubErrorCode());
     $this->assertEquals('exception', $exception->getErrorType());
@@ -65,13 +65,13 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     $params['error']['code'] = 102;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(102, $exception->getCode());
 
     $params['error']['code'] = 190;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(190, $exception->getCode());
 
     $params['error']['type'] = 'OAuthException';
@@ -79,31 +79,31 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     $params['error']['error_subcode'] = 458;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(458, $exception->getSubErrorCode());
 
     $params['error']['error_subcode'] = 460;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(460, $exception->getSubErrorCode());
 
     $params['error']['error_subcode'] = 463;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(463, $exception->getSubErrorCode());
 
     $params['error']['error_subcode'] = 467;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(467, $exception->getSubErrorCode());
 
     $params['error']['error_subcode'] = 0;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(0, $exception->getSubErrorCode());
   }
 
@@ -180,7 +180,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     ];
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(230, $exception->getCode());
     $this->assertEquals(459, $exception->getSubErrorCode());
     $this->assertEquals('exception', $exception->getErrorType());
@@ -191,11 +191,11 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     $params['error']['error_subcode'] = 464;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthenticationException', $exception->getPrevious());
     $this->assertEquals(464, $exception->getSubErrorCode());
   }
 
-  public function testPermissionExceptions()
+  public function testAuthorizationExceptions()
   {
     $params = [
       'error' => [
@@ -207,7 +207,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     ];
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookPermissionException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
     $this->assertEquals(10, $exception->getCode());
     $this->assertEquals(0, $exception->getSubErrorCode());
     $this->assertEquals('exception', $exception->getErrorType());
@@ -218,19 +218,19 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
     $params['error']['code'] = 200;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookPermissionException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
     $this->assertEquals(200, $exception->getCode());
 
     $params['error']['code'] = 250;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookPermissionException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
     $this->assertEquals(250, $exception->getCode());
 
     $params['error']['code'] = 299;
     $response = new FacebookResponse($this->request, json_encode($params), 401);
     $exception = FacebookResponseException::create($response);
-    $this->assertInstanceOf('Facebook\Exceptions\FacebookPermissionException', $exception->getPrevious());
+    $this->assertInstanceOf('Facebook\Exceptions\FacebookAuthorizationException', $exception->getPrevious());
     $this->assertEquals(299, $exception->getCode());
   }
 


### PR DESCRIPTION
How we don't see this before???

All current ``FacebookAuthorizationException`` are in fact authentication exceptions!
I also rename ``FacebookPermissionException`` to ``FacebookAuthorizationException`` because security is often authentication and authorization.