### PR TITLE
Prevent generation of logout url with app session.

### DIFF
--- a/src/Facebook/Entities/AccessToken.php
+++ b/src/Facebook/Entities/AccessToken.php
@@ -374,10 +374,7 @@ class AccessToken
    */
   public function isAppSession()
   {
-    if (strpos($this->accessToken, "|") !== FALSE) {
-      return true;
-    }
-    return false;
+    return strpos($this->accessToken, "|") !== false;
   }
 
 }

--- a/src/Facebook/Entities/AccessToken.php
+++ b/src/Facebook/Entities/AccessToken.php
@@ -367,4 +367,17 @@ class AccessToken
     return $this->accessToken;
   }
 
+  /**
+   * Returns true if the access token is an app session token.
+   *
+   * @return bool
+   */
+  public function isAppSession()
+  {
+    if (strpos($this->accessToken, "|") !== FALSE) {
+      return true;
+    }
+    return false;
+  }
+
 }

--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -143,9 +143,16 @@ class FacebookRedirectLoginHelper
    *   a successful logout
    *
    * @return string
+   *
+   * @throws FacebookSDKException
    */
   public function getLogoutUrl(FacebookSession $session, $next)
   {
+    if ($session->getAccessToken()->isAppSession()) {
+      throw new FacebookSDKException(
+        'Cannot generate a Logout URL with an App Session.', 722
+      );
+    }
     $params = array(
       'next' => $next,
       'access_token' => $session->getToken()

--- a/tests/FacebookRedirectLoginHelperTest.php
+++ b/tests/FacebookRedirectLoginHelperTest.php
@@ -2,6 +2,7 @@
 
 use Facebook\FacebookRedirectLoginHelper;
 use Facebook\FacebookRequest;
+use Facebook\FacebookSession;
 
 class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
 {
@@ -69,6 +70,26 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
         strpos($logoutUrl, $key . '=' . urlencode($value)) !== false
       );
     }
+  }
+
+  public function testLogoutURLFailsWithAppSession()
+  {
+    $helper = new FacebookRedirectLoginHelper(
+      self::REDIRECT_URL,
+      FacebookTestCredentials::$appId,
+      FacebookTestCredentials::$appSecret
+    );
+    $helper->disableSessionStatusCheck();
+    $session = FacebookSession::newAppSession(
+      FacebookTestCredentials::$appId,
+      FacebookTestCredentials::$appSecret
+    );
+    $this->setExpectedException(
+      'Facebook\\FacebookSDKException', 'Cannot generate a Logout URL with an App Session.'
+    );
+    $logoutUrl = $helper->getLogoutUrl(
+      $session, self::REDIRECT_URL
+    );
   }
   
   public function testCSPRNG()

--- a/tests/FacebookRedirectLoginHelperTest.php
+++ b/tests/FacebookRedirectLoginHelperTest.php
@@ -80,14 +80,11 @@ class FacebookRedirectLoginHelperTest extends PHPUnit_Framework_TestCase
       FacebookTestCredentials::$appSecret
     );
     $helper->disableSessionStatusCheck();
-    $session = FacebookSession::newAppSession(
-      FacebookTestCredentials::$appId,
-      FacebookTestCredentials::$appSecret
-    );
+    $session = FacebookTestHelper::getAppSession();
     $this->setExpectedException(
       'Facebook\\FacebookSDKException', 'Cannot generate a Logout URL with an App Session.'
     );
-    $logoutUrl = $helper->getLogoutUrl(
+    $helper->getLogoutUrl(
       $session, self::REDIRECT_URL
     );
   }


### PR DESCRIPTION
Using getLogoutUrl with an app session can leak the appSecret.