### PR TITLE
Add mandatory param to the RedirectLoginHelper constructor

### DIFF
--- a/docs/sdk_getting_started.fbmd
+++ b/docs/sdk_getting_started.fbmd
@@ -61,7 +61,7 @@ $loginUrl = $helper->getLoginUrl();
 ~~~~
 
 ~~~~
-$helper = new FacebookRedirectLoginHelper();
+$helper = new FacebookRedirectLoginHelper('your redirect URL here');
 try {
   $session = $helper->getSessionFromRedirect();
 } catch(FacebookRequestException $ex) {


### PR DESCRIPTION
The constructor is :

public function __construct($redirectUrl, $appId = null, $appSecret = null)

The first param $redirectUrl is therefore mandatory.