### PR TITLE
Curl handler check

### DIFF
--- a/src/Facebook/HttpClients/FacebookCurl.php
+++ b/src/Facebook/HttpClients/FacebookCurl.php
@@ -35,14 +35,16 @@ class FacebookCurl
   /**
    * @var resource Curl resource instance
    */
-  protected $curl;
+  protected $curl = null;
 
   /**
    * Make a new curl reference instance
    */
   public function init()
   {
-    $this->curl = curl_init();
+    if ($this->curl === null) {
+        $this->curl = curl_init();
+    }
   }
 
   /**


### PR DESCRIPTION
This adds a null initiator to $curl property of FacebookCurl and a check in the init method so previously created handlers aren't stepped on.