### PR TITLE
Adding GraphAchievement Node class

### DIFF
--- a/src/Facebook/GraphNodes/GraphAchievement.php
+++ b/src/Facebook/GraphNodes/GraphAchievement.php
@@ -51,7 +51,7 @@ class GraphAchievement extends GraphObject
     /**
      * Returns the user who achieved this.
      *
-     * @return string|null
+     * @return GraphUser|null
      */
     public function getFrom()
     {
@@ -61,7 +61,7 @@ class GraphAchievement extends GraphObject
     /**
      * Returns the time at which this was achieved.
      *
-     * @return string|null
+     * @return \DateTime|null
      */
     public function getPublishTime()
     {
@@ -71,7 +71,7 @@ class GraphAchievement extends GraphObject
     /**
      * Returns the app in which the user achieved this.
      *
-     * @return string|null
+     * @return GraphApplication|null
      */
     public function getApplication()
     {
@@ -82,7 +82,7 @@ class GraphAchievement extends GraphObject
      * Returns information about the achievement type this instance is
      * connected with.
      *
-     * @return string|null
+     * @return array|null
      */
     public function getData()
     {
@@ -105,10 +105,10 @@ class GraphAchievement extends GraphObject
      * Indicates whether gaining the achievement published a feed story for
      * the user.
      *
-     * @return boolean
+     * @return boolean|null
      */
     public function isNoFeedStory()
     {
-        return (bool) $this->getProperty('no_feed_story');
+        return $this->getProperty('no_feed_story');
     }
 }

--- a/src/Facebook/GraphNodes/GraphAchievement.php
+++ b/src/Facebook/GraphNodes/GraphAchievement.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\GraphNodes;
+
+/**
+ * Class GraphAchievement
+ * @package Facebook
+ */
+
+class GraphAchievement extends GraphObject
+{
+    /**
+     * @var array Maps object key names to Graph object types.
+     */
+    protected static $graphObjectMap = [
+        'from' => '\Facebook\GraphNodes\GraphUser',
+        'application' => '\Facebook\GraphNodes\GraphApplication',
+    ];
+
+    /**
+     * Returns the ID for the achievement.
+     *
+     * @return string|null
+     */
+    public function getId()
+    {
+        return $this->getProperty('id');
+    }
+
+    /**
+     * Returns the user who achieved this.
+     *
+     * @return string|null
+     */
+    public function getFrom()
+    {
+        return $this->getProperty('from');
+    }
+
+    /**
+     * Returns the time at which this was achieved.
+     *
+     * @return string|null
+     */
+    public function getPublishTime()
+    {
+        return $this->getProperty('publish_time');
+    }
+
+    /**
+     * Returns the app in which the user achieved this.
+     *
+     * @return string|null
+     */
+    public function getApplication()
+    {
+        return $this->getProperty('application');
+    }
+
+    /**
+     * Returns information about the achievement type this instance is
+     * connected with.
+     *
+     * @return string|null
+     */
+    public function getData()
+    {
+        return $this->getProperty('data');
+    }
+
+    /**
+     * Returns the type of achievement.
+     *
+     * @see https://developers.facebook.com/docs/graph-api/reference/v2.2/achievement
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'game.achievement';
+    }
+
+    /**
+     * Indicates whether gaining the achievement published a feed story for
+     * the user.
+     *
+     * @return boolean
+     */
+    public function isNoFeedStory()
+    {
+        return (bool) $this->getProperty('no_feed_story');
+    }
+}

--- a/src/Facebook/GraphNodes/GraphApplication.php
+++ b/src/Facebook/GraphNodes/GraphApplication.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\GraphNodes;
+
+/**
+ * Class GraphApplication
+ * @package Facebook
+ */
+
+class GraphApplication extends GraphObject
+{
+    /**
+     * Returns the ID for the application.
+     *
+     * @return string|null
+     */
+    public function getId()
+    {
+        return $this->getProperty('id');
+    }
+}

--- a/src/Facebook/GraphNodes/GraphObject.php
+++ b/src/Facebook/GraphNodes/GraphObject.php
@@ -152,6 +152,7 @@ class GraphObject extends Collection
         'issued_at',
         'expires_at',
         'birthday',
+        'publish_time'
       ], true);
   }
 

--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -92,6 +92,18 @@ class GraphObjectFactory
   }
 
   /**
+   * Convenience method for creating a GraphAchievement collection.
+   *
+   * @return GraphAchievement
+   *
+   * @throws FacebookSDKException
+   */
+  public function makeGraphAchievement()
+  {
+    return $this->makeGraphObject(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphAchievement');
+  }
+
+  /**
    * Convenience method for creating a GraphAlbum collection.
    *
    * @return GraphAlbum
@@ -306,7 +318,7 @@ class GraphObjectFactory
 
     // We'll need to make an edge endpoint for this in case it's a GraphList (for cursor pagination)
     $parentGraphEdgeEndpoint = $parentNodeId && $parentKey ? '/' . $parentNodeId . '/' . $parentKey : null;
-    
+
     return new GraphList($this->response->getRequest(), $dataList, $metaData, $parentGraphEdgeEndpoint, $subclassName);
   }
 

--- a/tests/GraphNodes/GraphAchievementTest.php
+++ b/tests/GraphNodes/GraphAchievementTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\GraphNodes;
+
+class GraphAchievementTest extends GraphNodeTest
+{
+
+  public function testIdIsString()
+  {
+        $dataFromGraph = [
+            'id' => '1337'
+        ];
+
+        $factory = $this->makeFactoryWithData($dataFromGraph);
+        $graphObject = $factory->makeGraphAchievement();
+
+        $id = $graphObject->getId();
+
+        $this->assertEquals($dataFromGraph['id'], $id);
+  }
+
+  public function testTypeIsAlwaysString()
+  {
+        $dataFromGraph = [
+            'id' => '1337'
+        ];
+
+        $factory = $this->makeFactoryWithData($dataFromGraph);
+        $graphObject = $factory->makeGraphAchievement();
+
+        $type = $graphObject->getType();
+
+        $this->assertEquals('game.achievement', $type);
+  }
+
+  public function testNoFeedStoryIsBoolean()
+  {
+        $dataFromGraph = [
+            'no_feed_story' => (rand(0,1) == 1)
+        ];
+
+        $factory = $this->makeFactoryWithData($dataFromGraph);
+        $graphObject = $factory->makeGraphAchievement();
+
+        $isNoFeedStory = $graphObject->isNoFeedStory();
+
+        $this->assertTrue(is_bool($isNoFeedStory));
+  }
+
+  public function testDatesGetCastToDateTime()
+  {
+        $dataFromGraph = [
+            'publish_time' => '2014-07-15T03:54:34+0000'
+        ];
+
+        $factory = $this->makeFactoryWithData($dataFromGraph);
+        $graphObject = $factory->makeGraphAchievement();
+
+        $publishTime = $graphObject->getPublishTime();
+
+        $this->assertInstanceOf('DateTime', $publishTime);
+  }
+
+  public function testFromGetsCastAsGraphUser()
+  {
+        $dataFromGraph = [
+            'from' => [
+                'id' => '1337',
+                'name' => 'Foo McBar'
+            ]
+        ];
+
+        $factory = $this->makeFactoryWithData($dataFromGraph);
+        $graphObject = $factory->makeGraphAchievement();
+
+        $from = $graphObject->getFrom();
+
+        $this->assertInstanceOf('\Facebook\GraphNodes\GraphUser', $from);
+  }
+
+  public function testApplicationGetsCastAsGraphApplication()
+  {
+        $dataFromGraph = [
+            'application' => [
+                'id' => '1337'
+            ]
+        ];
+
+        $factory = $this->makeFactoryWithData($dataFromGraph);
+        $graphObject = $factory->makeGraphAchievement();
+
+        $app = $graphObject->getApplication();
+
+        $this->assertInstanceOf('\Facebook\GraphNodes\GraphApplication', $app);
+  }
+}

--- a/tests/GraphNodes/GraphNodeTest.php
+++ b/tests/GraphNodes/GraphNodeTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\GraphNodes;
+
+use Mockery as m;
+use Facebook\GraphNodes\GraphObjectFactory;
+
+abstract class GraphNodeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Facebook\FacebookResponse
+     */
+    protected $responseMock;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->responseMock = m::mock('\Facebook\FacebookResponse');
+    }
+
+    protected function makeFactoryWithData($data)
+    {
+        $this->responseMock
+            ->shouldReceive('getDecodedBody')
+            ->once()
+            ->andReturn($data);
+        return new GraphObjectFactory($this->responseMock);
+    }
+}

--- a/tests/GraphNodes/GraphNodeTest.php
+++ b/tests/GraphNodes/GraphNodeTest.php
@@ -29,7 +29,7 @@ use Facebook\GraphNodes\GraphObjectFactory;
 abstract class GraphNodeTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var \Facebook\FacebookResponse
+     * @var \Facebook\FacebookResponse|\Mockery\MockInterface
      */
     protected $responseMock;
 


### PR DESCRIPTION
In an effort to add approachable classes and objects to the library, and prompted by a laundry list item in https://github.com/SammyK/facebook-php-sdk-v4/issues/1, I have added a node class for "achievement" 

https://developers.facebook.com/docs/graph-api/reference/v2.2/achievement

This is my first contribution adding Node classes like this, I would like to know if there are any specific aspects of this implementation that should be refined before moving forward with adding additional classes.

I also created bare-bones class for the "application" node. This will need more energy later.

Finally, I created a base abstract `GraphNodeTest ` to be used to move some code repetition away from the individual Node test classes.