### PR TITLE
Better Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ php:
   - 5.6
   - hhvm
 
-before_script:
+before_install:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+
+install:
+  - composer install --prefer-source --no-interaction
 
 script:
-  - phpunit --coverage-text --exclude-group integration
+  - vendor/bin/phpunit --coverage-text --exclude-group integration
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 5.6
   - hhvm
 
+sudo: false
+
 before_install:
   - composer self-update
 


### PR DESCRIPTION
- Use `before_install` and `install`
- Remove deprecated composer `--dev` option
- Use the required PHPUnit to run tests