### PR TITLE
getTimezone for GraphUser

### DIFF
--- a/src/Facebook/GraphUser.php
+++ b/src/Facebook/GraphUser.php
@@ -132,4 +132,13 @@ class GraphUser extends GraphObject
     return $this->getProperty('location', GraphLocation::className());
   }
 
+  /**
+   * Returns the timezone for the user as a int if present.
+   *
+   * @return string|null
+   */
+  public function getTimezone()
+  {
+    return $this->getProperty('timezone');
+  }
 }


### PR DESCRIPTION
Since 'timezone' is considered a core element of the User object (and I need it) I've included it in GraphUser