### PR TITLE
Add PHP CodeSniffer and CONTRIBUTION instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,44 @@
 Contributing
 ------------
 
-For us to accept contributions you will have to first have signed the
-[Contributor License Agreement](https://developers.facebook.com/opensource/cla).
+Contributions are **welcome** and will be fully **credited**.
 
-When committing, keep all lines to less than 80 characters, and try to
-follow the existing style.
+We accept contributions via Pull Requests on [Github](https://github.com/facebook/facebook-php-sdk-v4).
 
-Before creating a pull request, squash your commits into a single commit.
 
-Add the comments where needed, and provide ample explanation in the
-commit message.
+## Pull Requests
+
+- **Sign the CLA** - For us to accept contributions you will have to first have signed the
+  [Contributor License Agreement](https://developers.facebook.com/opensource/cla).
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to run [PHP Code Sniffer](#running-php-code-sniffer) as you code.
+
+- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
+
+- **Document any change in behaviour** - Make sure the README and the [documentation](https://github.com/facebook/facebook-php-sdk-v4/tree/master/docs) are kept up-to-date.
+
+- **Create topic branches** - Don't ask us to pull from your master branch.
+
+- **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
+
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
+
+- **Ensure tests pass!** - Please [run the tests](#running-tests) before submitting your pull request, and make sure they pass. We won't accept a patch until all tests pass.
+
+- **Ensure no coding standards violations** - Please [run PHP Code Sniffer](#running-php-code-sniffer) using the PSR-2 standard before submitting your pull request. A violation will cause the build to fail, so please make sure there are no violations. We can't accept a patch if the build fails.
+
+
+## Running Tests
+
+``` bash
+$ ./vendor/bin/phpunit
+```
+
+
+## Running PHP Code Sniffer
+
+``` bash
+$ ./vendor/bin/phpcs src --standard=psr2 -sp
+```
+
+**Happy coding**!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,16 @@ $ ./vendor/bin/phpunit
 
 ## Running PHP Code Sniffer
 
+You can install [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer) globally with composer.
+
 ``` bash
-$ ./vendor/bin/phpcs src --standard=psr2 -sp
+$ composer global require squizlabs/php_codesniffer
+```
+
+Then you can `cd` into the Facebook PHP SDK folder and run Code Sniffer against the `src/` directory.
+
+``` bash
+$ ~/.composer/vendor/bin/phpcs src --standard=psr2 -sp
 ```
 
 **Happy coding**!

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Facebook SDK for PHP
 ====================
 
 [![Build Status](https://img.shields.io/travis/facebook/facebook-php-sdk-v4/master.svg)](https://travis-ci.org/facebook/facebook-php-sdk-v4)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/?branch=master)
 [![Development Version](https://img.shields.io/badge/Development%20Version-4.1.0-orange.svg)](https://packagist.org/packages/facebook/php-sdk-v4)
 
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.8",
+        "squizlabs/php_codesniffer": "~2.0",
         "guzzlehttp/guzzle": "~5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.8",
-        "squizlabs/php_codesniffer": "~2.0",
         "guzzlehttp/guzzle": "~5.0"
     },
     "suggest": {


### PR DESCRIPTION
Hey @gfosco! In preparation for [Chi PHP UG's open source workshop](http://www.meetup.com/Chicago-PHP-User-Group/events/219902483/) tomorrow, I've added the Code Sniffer dev dependency as a way to check files for PSR-2 before committing them. And I added some more instructions to the CONTRIBUTING file. :)

PS: I'm working hard on the docs as well. I'm about 50% done. :)