### PR TITLE
Bring Facebook\Http src and tests into PSR-2 compliance

### DIFF
--- a/src/Facebook/Http/GraphRawResponse.php
+++ b/src/Facebook/Http/GraphRawResponse.php
@@ -30,109 +30,108 @@ namespace Facebook\Http;
 class GraphRawResponse
 {
 
-  /**
-   * @var array The response headers in the form of an associative array.
-   */
-  protected $headers;
+    /**
+     * @var array The response headers in the form of an associative array.
+     */
+    protected $headers;
 
-  /**
-   * @var string The raw response body.
-   */
-  protected $body;
+    /**
+     * @var string The raw response body.
+     */
+    protected $body;
 
-  /**
-   * @var int The HTTP status response code.
-   */
-  protected $httpResponseCode;
+    /**
+     * @var int The HTTP status response code.
+     */
+    protected $httpResponseCode;
 
-  /**
-   * Creates a new GraphRawResponse entity.
-   *
-   * @param string|array $headers The headers as a raw string or array.
-   * @param string $body The raw response body.
-   * @param int $httpStatusCode The HTTP response code (if sending headers as parsed array).
-   */
-  public function __construct($headers, $body, $httpStatusCode = null)
-  {
-    if (is_numeric($httpStatusCode)) {
-      $this->httpResponseCode = (int) $httpStatusCode;
+    /**
+     * Creates a new GraphRawResponse entity.
+     *
+     * @param string|array $headers The headers as a raw string or array.
+     * @param string $body The raw response body.
+     * @param int $httpStatusCode The HTTP response code (if sending headers as parsed array).
+     */
+    public function __construct($headers, $body, $httpStatusCode = null)
+    {
+        if (is_numeric($httpStatusCode)) {
+            $this->httpResponseCode = (int) $httpStatusCode;
+        }
+
+        if (is_array($headers)) {
+            $this->headers = $headers;
+        } else {
+            $this->setHeadersFromString($headers);
+        }
+
+        $this->body = $body;
     }
 
-    if (is_array($headers)) {
-      $this->headers = $headers;
-    } else {
-      $this->setHeadersFromString($headers);
+    /**
+     * Return the response headers.
+     *
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
     }
 
-    $this->body = $body;
-  }
-
-  /**
-   * Return the response headers.
-   *
-   * @return array
-   */
-  public function getHeaders()
-  {
-    return $this->headers;
-  }
-
-  /**
-   * Return the body of the response.
-   *
-   * @return string
-   */
-  public function getBody()
-  {
-    return $this->body;
-  }
-
-  /**
-   * Return the HTTP response code.
-   *
-   * @return int
-   */
-  public function getHttpResponseCode()
-  {
-    return $this->httpResponseCode;
-  }
-
-  /**
-   * Sets the HTTP response code from a raw header.
-   *
-   * @param string $rawResponseHeader
-   */
-  public function setHttpResponseCodeFromHeader($rawResponseHeader)
-  {
-    preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
-    $this->httpResponseCode = (int) $match[1];
-  }
-
-  /**
-   * Parse the raw headers and set as an array.
-   *
-   * @param string $rawHeaders The raw headers from the response.
-   */
-  protected function setHeadersFromString($rawHeaders)
-  {
-    // Normalize line breaks
-    $rawHeaders = str_replace("\r\n", "\n", $rawHeaders);
-
-    // There will be multiple headers if a 301 was followed
-    // or a proxy was followed, etc
-    $headerCollection = explode("\n\n", trim($rawHeaders));
-    // We just want the last response (at the end)
-    $rawHeader = array_pop($headerCollection);
-
-    $headerComponents = explode("\n", $rawHeader);
-    foreach ($headerComponents as $line) {
-      if (strpos($line, ': ') === false) {
-        $this->setHttpResponseCodeFromHeader($line);
-      } else {
-        list ($key, $value) = explode(': ', $line);
-        $this->headers[$key] = $value;
-      }
+    /**
+     * Return the body of the response.
+     *
+     * @return string
+     */
+    public function getBody()
+    {
+        return $this->body;
     }
-  }
 
+    /**
+     * Return the HTTP response code.
+     *
+     * @return int
+     */
+    public function getHttpResponseCode()
+    {
+        return $this->httpResponseCode;
+    }
+
+    /**
+     * Sets the HTTP response code from a raw header.
+     *
+     * @param string $rawResponseHeader
+     */
+    public function setHttpResponseCodeFromHeader($rawResponseHeader)
+    {
+        preg_match('|HTTP/\d\.\d\s+(\d+)\s+.*|', $rawResponseHeader, $match);
+        $this->httpResponseCode = (int) $match[1];
+    }
+
+    /**
+     * Parse the raw headers and set as an array.
+     *
+     * @param string $rawHeaders The raw headers from the response.
+     */
+    protected function setHeadersFromString($rawHeaders)
+    {
+        // Normalize line breaks
+        $rawHeaders = str_replace("\r\n", "\n", $rawHeaders);
+
+        // There will be multiple headers if a 301 was followed
+        // or a proxy was followed, etc
+        $headerCollection = explode("\n\n", trim($rawHeaders));
+        // We just want the last response (at the end)
+        $rawHeader = array_pop($headerCollection);
+
+        $headerComponents = explode("\n", $rawHeader);
+        foreach ($headerComponents as $line) {
+            if (strpos($line, ': ') === false) {
+                $this->setHttpResponseCodeFromHeader($line);
+            } else {
+                list ($key, $value) = explode(': ', $line);
+                $this->headers[$key] = $value;
+            }
+        }
+    }
 }

--- a/src/Facebook/Http/RequestBodyInterface.php
+++ b/src/Facebook/Http/RequestBodyInterface.php
@@ -30,11 +30,10 @@ namespace Facebook\Http;
 interface RequestBodyInterface
 {
 
-  /**
-   * Get the body of the request to send to Graph.
-   *
-   * @return string
-   */
-  public function getBody();
-
+    /**
+    * Get the body of the request to send to Graph.
+    *
+    * @return string
+    */
+    public function getBody();
 }

--- a/src/Facebook/Http/RequestBodyMultipart.php
+++ b/src/Facebook/Http/RequestBodyMultipart.php
@@ -37,117 +37,113 @@ use Facebook\FileUpload\FacebookFile;
 class RequestBodyMultipart implements RequestBodyInterface
 {
 
-  /**
-   * @var string The boundary.
-   */
-  protected $boundary;
+    /**
+     * @var string The boundary.
+     */
+    protected $boundary;
 
-  /**
-   * @var array The parameters to send with this request.
-   */
-  protected $params = [];
+    /**
+     * @var array The parameters to send with this request.
+     */
+    protected $params = [];
 
-  /**
-   * @var array The files to send with this request.
-   */
-  protected $files = [];
+    /**
+     * @var array The files to send with this request.
+     */
+    protected $files = [];
 
-  /**
-   * @param array  $params   The parameters to send with this request.
-   * @param array  $files    The files to send with this request.
-   * @param string $boundary Provide a specific boundary.
-   */
-  public function __construct(
-    array $params = [],
-    array $files = [],
-    $boundary = null
-  ) {
-    $this->params = $params;
-    $this->files = $files;
-    $this->boundary = $boundary ?: uniqid();
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function getBody()
-  {
-    $body = '';
-
-    // Compile normal params
-    foreach ($this->params as $k => $v) {
-      $body .= $this->getParamString($k, $v);
+    /**
+     * @param array  $params   The parameters to send with this request.
+     * @param array  $files    The files to send with this request.
+     * @param string $boundary Provide a specific boundary.
+     */
+    public function __construct(array $params = [], array $files = [], $boundary = null)
+    {
+        $this->params = $params;
+        $this->files = $files;
+        $this->boundary = $boundary ?: uniqid();
     }
 
-    // Compile files
-    foreach ($this->files as $k => $v) {
-      $body .= $this->getFileString($k, $v);
+    /**
+     * @inheritdoc
+     */
+    public function getBody()
+    {
+        $body = '';
+
+        // Compile normal params
+        foreach ($this->params as $k => $v) {
+            $body .= $this->getParamString($k, $v);
+        }
+
+        // Compile files
+        foreach ($this->files as $k => $v) {
+            $body .= $this->getFileString($k, $v);
+        }
+
+        // Peace out
+        $body .= "--{$this->boundary}--\r\n";
+
+        return $body;
     }
 
-    // Peace out
-    $body .= "--{$this->boundary}--\r\n";
+    /**
+     * Get the boundary
+     *
+     * @return string
+     */
+    public function getBoundary()
+    {
+        return $this->boundary;
+    }
 
-    return $body;
-  }
+    /**
+     * Get the string needed to transfer a file.
+     *
+     * @param string $name
+     * @param FacebookFile $file
+     *
+     * @return string
+     */
+    private function getFileString($name, FacebookFile $file)
+    {
+        return sprintf(
+            "--%s\r\nContent-Disposition: form-data; name=\"%s\"; filename=\"%s\"%s\r\n\r\n%s\r\n",
+            $this->boundary,
+            $name,
+            $file->getFileName(),
+            $this->getFileHeaders($file),
+            $file->getContents()
+        );
+    }
 
-  /**
-   * Get the boundary
-   *
-   * @return string
-   */
-  public function getBoundary()
-  {
-    return $this->boundary;
-  }
+    /**
+     * Get the string needed to transfer a POST field.
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return string
+     */
+    private function getParamString($name, $value)
+    {
+        return sprintf(
+            "--%s\r\nContent-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n",
+            $this->boundary,
+            $name,
+            $value
+        );
+    }
 
-  /**
-   * Get the string needed to transfer a file.
-   *
-   * @param string $name
-   * @param FacebookFile $file
-   *
-   * @return string
-   */
-  private function getFileString($name, FacebookFile $file)
-  {
-    return sprintf(
-      "--%s\r\nContent-Disposition: form-data; name=\"%s\"; filename=\"%s\"%s\r\n\r\n%s\r\n",
-      $this->boundary,
-      $name,
-      $file->getFileName(),
-      $this->getFileHeaders($file),
-      $file->getContents()
-    );
-  }
-
-  /**
-   * Get the string needed to transfer a POST field.
-   *
-   * @param string $name
-   * @param string $value
-   *
-   * @return string
-   */
-  private function getParamString($name, $value)
-  {
-    return sprintf(
-      "--%s\r\nContent-Disposition: form-data; name=\"%s\"\r\n\r\n%s\r\n",
-      $this->boundary,
-      $name,
-      $value
-    );
-  }
-
-  /**
-   * Get the headers needed before transferring the content of a POST file.
-   *
-   * @param FacebookFile $file
-   *
-   * @return string
-   */
-  protected function getFileHeaders(FacebookFile $file)
-  {
-    return "\r\nContent-Type: {$file->getMimetype()}";
-  }
-
+    /**
+     * Get the headers needed before transferring the content of a POST file.
+     *
+     * @param FacebookFile $file
+     *
+     * @return string
+     */
+    protected function getFileHeaders(FacebookFile $file)
+    {
+        return "\r\nContent-Type: {$file->getMimetype()}";
+    }
 }

--- a/src/Facebook/Http/RequestBodyUrlEncoded.php
+++ b/src/Facebook/Http/RequestBodyUrlEncoded.php
@@ -30,27 +30,26 @@ namespace Facebook\Http;
 class RequestBodyUrlEncoded implements RequestBodyInterface
 {
 
-  /**
-   * @var array The parameters to send with this request.
-   */
-  protected $params = [];
+    /**
+     * @var array The parameters to send with this request.
+     */
+    protected $params = [];
 
-  /**
-   * Creates a new GraphUrlEncodedBody entity.
-   *
-   * @param array $params
-   */
-  public function __construct(array $params)
-  {
-    $this->params = $params;
-  }
+    /**
+     * Creates a new GraphUrlEncodedBody entity.
+     *
+     * @param array $params
+     */
+    public function __construct(array $params)
+    {
+        $this->params = $params;
+    }
 
-  /**
-   * @inheritdoc
-   */
-  public function getBody()
-  {
-    return http_build_query($this->params, null, '&');
-  }
-
+    /**
+     * @inheritdoc
+     */
+    public function getBody()
+    {
+        return http_build_query($this->params, null, '&');
+    }
 }

--- a/tests/Http/GraphRawResponseTest.php
+++ b/tests/Http/GraphRawResponseTest.php
@@ -28,54 +28,55 @@ use Facebook\Http\GraphRawResponse;
 class GraphRawResponseTest extends \PHPUnit_Framework_TestCase
 {
 
-  protected $fakeRawProxyHeader = "HTTP/1.0 200 Connection established
+    protected $fakeRawProxyHeader = "HTTP/1.0 200 Connection established
 Proxy-agent: Kerio Control/7.1.1 build 1971\r\n\r\n";
-  protected $fakeRawHeader = "HTTP/1.1 200 OK
-Etag: \"9d86b21aa74d74e574bbb35ba13524a52deb96e3\"
+    protected $fakeRawHeader = <<<HEADER
+HTTP/1.1 200 OK
+Etag: "9d86b21aa74d74e574bbb35ba13524a52deb96e3"
 Content-Type: text/javascript; charset=UTF-8
 X-FB-Rev: 9244768
 Date: Mon, 19 May 2014 18:37:17 GMT
 X-FB-Debug: 02QQiffE7JG2rV6i/Agzd0gI2/OOQ2lk5UW0=
-Access-Control-Allow-Origin: *\r\n\r\n";
-  protected $fakeHeadersAsArray = [
-    'Etag' => '"9d86b21aa74d74e574bbb35ba13524a52deb96e3"',
-    'Content-Type' => 'text/javascript; charset=UTF-8',
-    'X-FB-Rev' => '9244768',
-    'Date' => 'Mon, 19 May 2014 18:37:17 GMT',
-    'X-FB-Debug' => '02QQiffE7JG2rV6i/Agzd0gI2/OOQ2lk5UW0=',
-    'Access-Control-Allow-Origin' => '*',
-  ];
-
-  public function testCanSetTheHeadersFromAnArray()
-  {
-    $myHeaders = [
-      'foo' => 'bar',
-      'baz' => 'faz',
+Access-Control-Allow-Origin: *\r\n\r\n
+HEADER;
+    protected $fakeHeadersAsArray = [
+        'Etag' => '"9d86b21aa74d74e574bbb35ba13524a52deb96e3"',
+        'Content-Type' => 'text/javascript; charset=UTF-8',
+        'X-FB-Rev' => '9244768',
+        'Date' => 'Mon, 19 May 2014 18:37:17 GMT',
+        'X-FB-Debug' => '02QQiffE7JG2rV6i/Agzd0gI2/OOQ2lk5UW0=',
+        'Access-Control-Allow-Origin' => '*',
     ];
-    $response = new GraphRawResponse($myHeaders, '');
-    $headers = $response->getHeaders();
 
-    $this->assertEquals($myHeaders, $headers);
-  }
+    public function testCanSetTheHeadersFromAnArray()
+    {
+        $myHeaders = [
+            'foo' => 'bar',
+            'baz' => 'faz',
+        ];
+        $response = new GraphRawResponse($myHeaders, '');
+        $headers = $response->getHeaders();
 
-  public function testCanSetTheHeadersFromAString()
-  {
-    $response = new GraphRawResponse($this->fakeRawHeader, '');
-    $headers = $response->getHeaders();
-    $httpResponseCode = $response->getHttpResponseCode();
+        $this->assertEquals($myHeaders, $headers);
+    }
 
-    $this->assertEquals($this->fakeHeadersAsArray, $headers);
-    $this->assertEquals(200, $httpResponseCode);
-  }
+    public function testCanSetTheHeadersFromAString()
+    {
+        $response = new GraphRawResponse($this->fakeRawHeader, '');
+        $headers = $response->getHeaders();
+        $httpResponseCode = $response->getHttpResponseCode();
 
-  public function testWillIgnoreProxyHeaders()
-  {
-    $response = new GraphRawResponse($this->fakeRawProxyHeader . $this->fakeRawHeader, '');
-    $headers = $response->getHeaders();
-    $httpResponseCode = $response->getHttpResponseCode();
+        $this->assertEquals($this->fakeHeadersAsArray, $headers);
+        $this->assertEquals(200, $httpResponseCode);
+    }
 
-    $this->assertEquals($this->fakeHeadersAsArray, $headers);
-    $this->assertEquals(200, $httpResponseCode);
-  }
+    public function testWillIgnoreProxyHeaders()
+    {
+        $response = new GraphRawResponse($this->fakeRawProxyHeader . $this->fakeRawHeader, '');
+        $headers = $response->getHeaders();
+        $httpResponseCode = $response->getHttpResponseCode();
 
+        $this->assertEquals($this->fakeHeadersAsArray, $headers);
+        $this->assertEquals(200, $httpResponseCode);
+    }
 }

--- a/tests/Http/RequestBodyMultipartTest.php
+++ b/tests/Http/RequestBodyMultipartTest.php
@@ -29,41 +29,40 @@ use Facebook\FileUpload\FacebookFile;
 class RequestBodyMultipartTest extends \PHPUnit_Framework_TestCase
 {
 
-  public function testCanProperlyEncodeAnArrayOfParams()
-  {
-    $message = new RequestBodyMultipart([
-        'foo' => 'bar',
-        'scawy_vawues' => '@FooBar is a real twitter handle.',
-      ], [], 'foo_boundary');
-    $body = $message->getBody();
+    public function testCanProperlyEncodeAnArrayOfParams()
+    {
+        $message = new RequestBodyMultipart([
+                'foo' => 'bar',
+                'scawy_vawues' => '@FooBar is a real twitter handle.',
+            ], [], 'foo_boundary');
+        $body = $message->getBody();
 
-    $expectedBody = "--foo_boundary\r\n";
-    $expectedBody .= "Content-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n";
-    $expectedBody .= "--foo_boundary\r\n";
-    $expectedBody .= "Content-Disposition: form-data; name=\"scawy_vawues\"\r\n\r\n@FooBar is a real twitter handle.\r\n";
-    $expectedBody .= "--foo_boundary--\r\n";
+        $expectedBody = "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"scawy_vawues\"\r\n\r\n@FooBar is a real twitter handle.\r\n";
+        $expectedBody .= "--foo_boundary--\r\n";
 
-    $this->assertEquals($expectedBody, $body);
-  }
+        $this->assertEquals($expectedBody, $body);
+    }
 
-  public function testCanProperlyEncodeFilesAndParams()
-  {
-    $file = new FacebookFile(__DIR__ . '/../foo.txt');
-    $message = new RequestBodyMultipart([
-        'foo' => 'bar',
-      ], [
-        'foo_file' => $file,
-      ], 'foo_boundary');
-    $body = $message->getBody();
+    public function testCanProperlyEncodeFilesAndParams()
+    {
+        $file = new FacebookFile(__DIR__ . '/../foo.txt');
+        $message = new RequestBodyMultipart([
+                'foo' => 'bar',
+            ], [
+                'foo_file' => $file,
+            ], 'foo_boundary');
+        $body = $message->getBody();
 
-    $expectedBody = "--foo_boundary\r\n";
-    $expectedBody .= "Content-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n";
-    $expectedBody .= "--foo_boundary\r\n";
-    $expectedBody .= "Content-Disposition: form-data; name=\"foo_file\"; filename=\"foo.txt\"\r\n";
-    $expectedBody .= "Content-Type: text/plain\r\n\r\nThis is a text file used for testing. Let's dance.\r\n";
-    $expectedBody .= "--foo_boundary--\r\n";
+        $expectedBody = "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"foo_file\"; filename=\"foo.txt\"\r\n";
+        $expectedBody .= "Content-Type: text/plain\r\n\r\nThis is a text file used for testing. Let's dance.\r\n";
+        $expectedBody .= "--foo_boundary--\r\n";
 
-    $this->assertEquals($expectedBody, $body);
-  }
-
+        $this->assertEquals($expectedBody, $body);
+    }
 }

--- a/tests/Http/RequestUrlEncodedTest.php
+++ b/tests/Http/RequestUrlEncodedTest.php
@@ -28,15 +28,14 @@ use Facebook\Http\RequestBodyUrlEncoded;
 class RequestBodyUrlEncodedTest extends \PHPUnit_Framework_TestCase
 {
 
-  public function testCanProperlyEncodeAnArrayOfParams()
-  {
-    $message = new RequestBodyUrlEncoded([
-        'foo' => 'bar',
-        'scawy_vawues' => '@FooBar is a real twitter handle.',
-      ]);
-    $body = $message->getBody();
+    public function testCanProperlyEncodeAnArrayOfParams()
+    {
+        $message = new RequestBodyUrlEncoded([
+            'foo' => 'bar',
+            'scawy_vawues' => '@FooBar is a real twitter handle.',
+        ]);
+        $body = $message->getBody();
 
-    $this->assertEquals('foo=bar&scawy_vawues=%40FooBar+is+a+real+twitter+handle.', $body);
-  }
-
+        $this->assertEquals('foo=bar&scawy_vawues=%40FooBar+is+a+real+twitter+handle.', $body);
+    }
 }


### PR DESCRIPTION
This brings the Facebook\Http namespace plus its tests into PSR-2 compliance