### PR TITLE
Bring Facebook/Authentication and associated tests in PSR-2 compliance

### DIFF
--- a/src/Facebook/Authentication/AccessToken.php
+++ b/src/Facebook/Authentication/AccessToken.php
@@ -30,132 +30,131 @@ namespace Facebook\Authentication;
 class AccessToken
 {
 
-  /**
-   * The access token value.
-   *
-   * @var string
-   */
-  protected $value = '';
+    /**
+     * The access token value.
+     *
+     * @var string
+     */
+    protected $value = '';
 
-  /**
-   * Date when token expires.
-   *
-   * @var \DateTime|null
-   */
-  protected $expiresAt;
+    /**
+     * Date when token expires.
+     *
+     * @var \DateTime|null
+     */
+    protected $expiresAt;
 
-  /**
-   * Create a new access token entity.
-   *
-   * @param string $accessToken
-   * @param int $expiresAt
-   */
-  public function __construct($accessToken, $expiresAt = 0)
-  {
-    $this->value = $accessToken;
-    if ($expiresAt) {
-      $this->setExpiresAtFromTimeStamp($expiresAt);
-    }
-  }
-
-  /**
-   * Generate an app secret proof to sign a request to Graph.
-   *
-   * @param string $appSecret The app secret.
-   *
-   * @return string
-   */
-  public function getAppSecretProof($appSecret)
-  {
-    return hash_hmac('sha256', $this->value, $appSecret);
-  }
-
-  /**
-   * Getter for expiresAt.
-   *
-   * @return \DateTime|null
-   */
-  public function getExpiresAt()
-  {
-    return $this->expiresAt;
-  }
-
-  /**
-   * Determines whether or not this is an app access token.
-   *
-   * @return bool
-   */
-  public function isAppAccessToken()
-  {
-    return strpos($this->value, '|') !== false;
-  }
-
-  /**
-   * Determines whether or not this is a long-lived token.
-   *
-   * @return bool
-   */
-  public function isLongLived()
-  {
-    if ($this->expiresAt) {
-      return $this->expiresAt->getTimestamp() > time() + (60 * 60 * 2);
+    /**
+     * Create a new access token entity.
+     *
+     * @param string $accessToken
+     * @param int $expiresAt
+     */
+    public function __construct($accessToken, $expiresAt = 0)
+    {
+        $this->value = $accessToken;
+        if ($expiresAt) {
+            $this->setExpiresAtFromTimeStamp($expiresAt);
+        }
     }
 
-    if ($this->isAppAccessToken()) {
-      return true;
+    /**
+     * Generate an app secret proof to sign a request to Graph.
+     *
+     * @param string $appSecret The app secret.
+     *
+     * @return string
+     */
+    public function getAppSecretProof($appSecret)
+    {
+        return hash_hmac('sha256', $this->value, $appSecret);
     }
 
-    return false;
-  }
-
-  /**
-   * Checks the expiration of the access token.
-   *
-   * @return boolean|null
-   */
-  public function isExpired()
-  {
-    if ($this->getExpiresAt() instanceof \DateTime) {
-      return $this->getExpiresAt()->getTimestamp() < time();
+    /**
+     * Getter for expiresAt.
+     *
+     * @return \DateTime|null
+     */
+    public function getExpiresAt()
+    {
+        return $this->expiresAt;
     }
 
-    if ($this->isAppAccessToken()) {
-      return false;
+    /**
+     * Determines whether or not this is an app access token.
+     *
+     * @return bool
+     */
+    public function isAppAccessToken()
+    {
+        return strpos($this->value, '|') !== false;
     }
 
-    return null;
-  }
+    /**
+     * Determines whether or not this is a long-lived token.
+     *
+     * @return bool
+     */
+    public function isLongLived()
+    {
+        if ($this->expiresAt) {
+            return $this->expiresAt->getTimestamp() > time() + (60 * 60 * 2);
+        }
 
-  /**
-   * Returns the access token as a string.
-   *
-   * @return string
-   */
-  public function getValue()
-  {
-    return $this->value;
-  }
+        if ($this->isAppAccessToken()) {
+            return true;
+        }
 
-  /**
-   * Returns the access token as a string.
-   *
-   * @return string
-   */
-  public function __toString()
-  {
-    return $this->getValue();
-  }
+        return false;
+    }
 
-  /**
-   * Setter for expires_at.
-   *
-   * @param int $timeStamp
-   */
-  protected function setExpiresAtFromTimeStamp($timeStamp)
-  {
-    $dt = new \DateTime();
-    $dt->setTimestamp($timeStamp);
-    $this->expiresAt = $dt;
-  }
+    /**
+     * Checks the expiration of the access token.
+     *
+     * @return boolean|null
+     */
+    public function isExpired()
+    {
+        if ($this->getExpiresAt() instanceof \DateTime) {
+            return $this->getExpiresAt()->getTimestamp() < time();
+        }
 
+        if ($this->isAppAccessToken()) {
+            return false;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the access token as a string.
+     *
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Returns the access token as a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getValue();
+    }
+
+    /**
+     * Setter for expires_at.
+     *
+     * @param int $timeStamp
+     */
+    protected function setExpiresAtFromTimeStamp($timeStamp)
+    {
+        $dt = new \DateTime();
+        $dt->setTimestamp($timeStamp);
+        $this->expiresAt = $dt;
+    }
 }

--- a/src/Facebook/Authentication/AccessTokenMetadata.php
+++ b/src/Facebook/Authentication/AccessTokenMetadata.php
@@ -35,340 +35,339 @@ use Facebook\Exceptions\FacebookSDKException;
 class AccessTokenMetadata
 {
 
-  /**
-   * The access token metadata.
-   *
-   * @var array
-   */
-  protected $metadata = [];
+    /**
+     * The access token metadata.
+     *
+     * @var array
+     */
+    protected $metadata = [];
 
-  /**
-   * Properties that should be cast as DateTime objects.
-   *
-   * @var array
-   */
-  protected static $dateProperties = ['expires_at', 'issued_at'];
+    /**
+     * Properties that should be cast as DateTime objects.
+     *
+     * @var array
+     */
+    protected static $dateProperties = ['expires_at', 'issued_at'];
 
-  /**
-   * @param array $metadata
-   *
-   * @throws FacebookSDKException
-   */
-  public function __construct(array $metadata)
-  {
-    if ( ! isset($metadata['data'])) {
-      throw new FacebookSDKException('Unexpected debug token response data.', 401);
+    /**
+     * @param array $metadata
+     *
+     * @throws FacebookSDKException
+     */
+    public function __construct(array $metadata)
+    {
+        if (! isset($metadata['data'])) {
+            throw new FacebookSDKException('Unexpected debug token response data.', 401);
+        }
+
+        $this->metadata = $metadata['data'];
+
+        $this->castTimestampsToDateTime();
     }
 
-    $this->metadata = $metadata['data'];
+    /**
+     * Returns a value from the metadata.
+     *
+     * @param string $field The property to retrieve.
+     * @param mixed $default The default to return if the property doesn't exist.
+     *
+     * @return mixed
+     */
+    public function getProperty($field, $default = null)
+    {
+        if (isset($this->metadata[$field])) {
+            return $this->metadata[$field];
+        }
 
-    $this->castTimestampsToDateTime();
-  }
-
-  /**
-   * Returns a value from the metadata.
-   *
-   * @param string $field The property to retrieve.
-   * @param mixed $default The default to return if the property doesn't exist.
-   *
-   * @return mixed
-   */
-  public function getProperty($field, $default = null)
-  {
-    if (isset($this->metadata[$field])) {
-      return $this->metadata[$field];
+        return $default;
     }
 
-    return $default;
-  }
+    /**
+     * Returns a value from a child property in the metadata.
+     *
+     * @param string $parentField The parent property.
+     * @param string $field The property to retrieve.
+     * @param mixed $default The default to return if the property doesn't exist.
+     *
+     * @return mixed
+     */
+    public function getChildProperty($parentField, $field, $default = null)
+    {
+        if (! isset($this->metadata[$parentField])) {
+            return $default;
+        }
 
-  /**
-   * Returns a value from a child property in the metadata.
-   *
-   * @param string $parentField The parent property.
-   * @param string $field The property to retrieve.
-   * @param mixed $default The default to return if the property doesn't exist.
-   *
-   * @return mixed
-   */
-  public function getChildProperty($parentField, $field, $default = null)
-  {
-    if ( ! isset($this->metadata[$parentField])) {
-      return $default;
+        if (! isset($this->metadata[$parentField][$field])) {
+            return $default;
+        }
+
+        return $this->metadata[$parentField][$field];
     }
 
-    if ( ! isset($this->metadata[$parentField][$field])) {
-      return $default;
+    /**
+     * Returns a value from the error metadata.
+     *
+     * @param string $field The property to retrieve.
+     * @param mixed $default The default to return if the property doesn't exist.
+     *
+     * @return mixed
+     */
+    public function getErrorProperty($field, $default = null)
+    {
+        return $this->getChildProperty('error', $field, $default);
     }
 
-    return $this->metadata[$parentField][$field];
-  }
-
-  /**
-   * Returns a value from the error metadata.
-   *
-   * @param string $field The property to retrieve.
-   * @param mixed $default The default to return if the property doesn't exist.
-   *
-   * @return mixed
-   */
-  public function getErrorProperty($field, $default = null)
-  {
-    return $this->getChildProperty('error', $field, $default);
-  }
-
-  /**
-   * Returns a value from the "metadata" metadata. *Brain explodes*
-   *
-   * @param string $field The property to retrieve.
-   * @param mixed $default The default to return if the property doesn't exist.
-   *
-   * @return mixed
-   */
-  public function getMetadataProperty($field, $default = null)
-  {
-    return $this->getChildProperty('metadata', $field, $default);
-  }
-
-  /**
-   * The ID of the application this access token is for.
-   *
-   * @return string|null
-   */
-  public function getAppId()
-  {
-    return $this->getProperty('app_id');
-  }
-
-  /**
-   * Name of the application this access token is for.
-   *
-   * @return string|null
-   */
-  public function getApplication()
-  {
-    return $this->getProperty('application');
-  }
-
-  /**
-   * Any error that a request to the graph api
-   * would return due to the access token.
-   *
-   * @return bool|null
-   */
-  public function isError()
-  {
-    return $this->getProperty('error') !== null;
-  }
-
-  /**
-   * The error code for the error.
-   *
-   * @return int|null
-   */
-  public function getErrorCode()
-  {
-    return $this->getErrorProperty('code');
-  }
-
-  /**
-   * The error message for the error.
-   *
-   * @return string|null
-   */
-  public function getErrorMessage()
-  {
-    return $this->getErrorProperty('message');
-  }
-
-  /**
-   * The error subcode for the error.
-   *
-   * @return int|null
-   */
-  public function getErrorSubcode()
-  {
-    return $this->getErrorProperty('subcode');
-  }
-
-  /**
-   * DateTime when this access token expires.
-   *
-   * @return \DateTime|null
-   */
-  public function getExpiresAt()
-  {
-    return $this->getProperty('expires_at');
-  }
-
-  /**
-   * Whether the access token is still valid or not.
-   *
-   * @return boolean|null
-   */
-  public function getIsValid()
-  {
-    return $this->getProperty('is_valid');
-  }
-
-  /**
-   * DateTime when this access token was issued.
-   *
-   * Note that the issued_at field is not returned
-   * for short-lived access tokens.
-   * @see https://developers.facebook.com/docs/facebook-login/access-tokens#debug
-   *
-   * @return \DateTime|null
-   */
-  public function getIssuedAt()
-  {
-    return $this->getProperty('issued_at');
-  }
-
-  /**
-   * General metadata associated with the access token.
-   * Can contain data like 'sso', 'auth_type', 'auth_nonce'.
-   *
-   * @return array|null
-   */
-  public function getMetadata()
-  {
-    return $this->getProperty('metadata');
-  }
-
-  /**
-   * The 'sso' child property from the 'metadata' parent property.
-   *
-   * @return string|null
-   */
-  public function getSso()
-  {
-    return $this->getMetadataProperty('sso');
-  }
-
-  /**
-   * The 'auth_type' child property from the 'metadata' parent property.
-   *
-   * @return string|null
-   */
-  public function getAuthType()
-  {
-    return $this->getMetadataProperty('auth_type');
-  }
-
-  /**
-   * The 'auth_nonce' child property from the 'metadata' parent property.
-   *
-   * @return string|null
-   */
-  public function getAuthNonce()
-  {
-    return $this->getMetadataProperty('auth_nonce');
-  }
-
-  /**
-   * For impersonated access tokens, the ID of
-   * the page this token contains.
-   *
-   * @return string|null
-   */
-  public function getProfileId()
-  {
-    return $this->getProperty('profile_id');
-  }
-
-  /**
-   * List of permissions that the user has granted for
-   * the app in this access token.
-   *
-   * @return array
-   */
-  public function getScopes()
-  {
-    return $this->getProperty('scopes');
-  }
-
-  /**
-   * The ID of the user this access token is for.
-   *
-   * @return string|null
-   */
-  public function getUserId()
-  {
-    return $this->getProperty('user_id');
-  }
-
-  /**
-   * Ensures the app ID from the access token
-   * metadata is what we expect.
-   *
-   * @param string $appId
-   *
-   * @throws FacebookSDKException
-   */
-  public function validateAppId($appId)
-  {
-    if ($this->getAppId() !== $appId) {
-      throw new FacebookSDKException('Access token metadata contains unexpected app ID.', 401);
-    }
-  }
-
-  /**
-   * Ensures the user ID from the access token
-   * metadata is what we expect.
-   *
-   * @param string $userId
-   *
-   * @throws FacebookSDKException
-   */
-  public function validateUserId($userId)
-  {
-    if ($this->getUserId() !== $userId) {
-      throw new FacebookSDKException('Access token metadata contains unexpected user ID.', 401);
-    }
-  }
-
-  /**
-   * Ensures the access token has not expired yet.
-   *
-   * @throws FacebookSDKException
-   */
-  public function validateExpiration()
-  {
-    if ( ! $this->getExpiresAt() instanceof \DateTime) {
-      return;
+    /**
+     * Returns a value from the "metadata" metadata. *Brain explodes*
+     *
+     * @param string $field The property to retrieve.
+     * @param mixed $default The default to return if the property doesn't exist.
+     *
+     * @return mixed
+     */
+    public function getMetadataProperty($field, $default = null)
+    {
+        return $this->getChildProperty('metadata', $field, $default);
     }
 
-    if ($this->getExpiresAt()->getTimestamp() < time()) {
-      throw new FacebookSDKException('Inspection of access token metadata shows that the access token has expired.', 401);
+    /**
+     * The ID of the application this access token is for.
+     *
+     * @return string|null
+     */
+    public function getAppId()
+    {
+        return $this->getProperty('app_id');
     }
-  }
 
-  /**
-   * Converts a unix timestamp into a DateTime entity.
-   *
-   * @param int $timestamp
-   *
-   * @return \DateTime
-   */
-  private function convertTimestampToDateTime($timestamp)
-  {
-    $dt = new \DateTime();
-    $dt->setTimestamp($timestamp);
-
-    return $dt;
-  }
-
-  /**
-   * Casts the unix timestamps as DateTime entities.
-   */
-  private function castTimestampsToDateTime()
-  {
-    foreach (static::$dateProperties as $key) {
-      if (isset($this->metadata[$key])) {
-        $this->metadata[$key] = $this->convertTimestampToDateTime($this->metadata[$key]);
-      }
+    /**
+     * Name of the application this access token is for.
+     *
+     * @return string|null
+     */
+    public function getApplication()
+    {
+        return $this->getProperty('application');
     }
-  }
 
+    /**
+     * Any error that a request to the graph api
+     * would return due to the access token.
+     *
+     * @return bool|null
+     */
+    public function isError()
+    {
+        return $this->getProperty('error') !== null;
+    }
+
+    /**
+     * The error code for the error.
+     *
+     * @return int|null
+     */
+    public function getErrorCode()
+    {
+        return $this->getErrorProperty('code');
+    }
+
+    /**
+     * The error message for the error.
+     *
+     * @return string|null
+     */
+    public function getErrorMessage()
+    {
+        return $this->getErrorProperty('message');
+    }
+
+    /**
+     * The error subcode for the error.
+     *
+     * @return int|null
+     */
+    public function getErrorSubcode()
+    {
+        return $this->getErrorProperty('subcode');
+    }
+
+    /**
+     * DateTime when this access token expires.
+     *
+     * @return \DateTime|null
+     */
+    public function getExpiresAt()
+    {
+        return $this->getProperty('expires_at');
+    }
+
+    /**
+     * Whether the access token is still valid or not.
+     *
+     * @return boolean|null
+     */
+    public function getIsValid()
+    {
+        return $this->getProperty('is_valid');
+    }
+
+    /**
+     * DateTime when this access token was issued.
+     *
+     * Note that the issued_at field is not returned
+     * for short-lived access tokens.
+     * @see https://developers.facebook.com/docs/facebook-login/access-tokens#debug
+     *
+     * @return \DateTime|null
+     */
+    public function getIssuedAt()
+    {
+        return $this->getProperty('issued_at');
+    }
+
+    /**
+     * General metadata associated with the access token.
+     * Can contain data like 'sso', 'auth_type', 'auth_nonce'.
+     *
+     * @return array|null
+     */
+    public function getMetadata()
+    {
+        return $this->getProperty('metadata');
+    }
+
+    /**
+     * The 'sso' child property from the 'metadata' parent property.
+     *
+     * @return string|null
+     */
+    public function getSso()
+    {
+        return $this->getMetadataProperty('sso');
+    }
+
+    /**
+     * The 'auth_type' child property from the 'metadata' parent property.
+     *
+     * @return string|null
+     */
+    public function getAuthType()
+    {
+        return $this->getMetadataProperty('auth_type');
+    }
+
+    /**
+     * The 'auth_nonce' child property from the 'metadata' parent property.
+     *
+     * @return string|null
+     */
+    public function getAuthNonce()
+    {
+        return $this->getMetadataProperty('auth_nonce');
+    }
+
+    /**
+     * For impersonated access tokens, the ID of
+     * the page this token contains.
+     *
+     * @return string|null
+     */
+    public function getProfileId()
+    {
+        return $this->getProperty('profile_id');
+    }
+
+    /**
+     * List of permissions that the user has granted for
+     * the app in this access token.
+     *
+     * @return array
+     */
+    public function getScopes()
+    {
+        return $this->getProperty('scopes');
+    }
+
+    /**
+     * The ID of the user this access token is for.
+     *
+     * @return string|null
+     */
+    public function getUserId()
+    {
+        return $this->getProperty('user_id');
+    }
+
+    /**
+     * Ensures the app ID from the access token
+     * metadata is what we expect.
+     *
+     * @param string $appId
+     *
+     * @throws FacebookSDKException
+     */
+    public function validateAppId($appId)
+    {
+        if ($this->getAppId() !== $appId) {
+            throw new FacebookSDKException('Access token metadata contains unexpected app ID.', 401);
+        }
+    }
+
+    /**
+     * Ensures the user ID from the access token
+     * metadata is what we expect.
+     *
+     * @param string $userId
+     *
+     * @throws FacebookSDKException
+     */
+    public function validateUserId($userId)
+    {
+        if ($this->getUserId() !== $userId) {
+            throw new FacebookSDKException('Access token metadata contains unexpected user ID.', 401);
+        }
+    }
+
+    /**
+     * Ensures the access token has not expired yet.
+     *
+     * @throws FacebookSDKException
+     */
+    public function validateExpiration()
+    {
+        if (! $this->getExpiresAt() instanceof \DateTime) {
+            return;
+        }
+
+        if ($this->getExpiresAt()->getTimestamp() < time()) {
+            throw new FacebookSDKException('Inspection of access token metadata shows that the access token has expired.', 401);
+        }
+    }
+
+    /**
+     * Converts a unix timestamp into a DateTime entity.
+     *
+     * @param int $timestamp
+     *
+     * @return \DateTime
+     */
+    private function convertTimestampToDateTime($timestamp)
+    {
+        $dt = new \DateTime();
+        $dt->setTimestamp($timestamp);
+
+        return $dt;
+    }
+
+    /**
+     * Casts the unix timestamps as DateTime entities.
+     */
+    private function castTimestampsToDateTime()
+    {
+        foreach (static::$dateProperties as $key) {
+            if (isset($this->metadata[$key])) {
+                $this->metadata[$key] = $this->convertTimestampToDateTime($this->metadata[$key]);
+            }
+        }
+    }
 }

--- a/src/Facebook/Authentication/OAuth2Client.php
+++ b/src/Facebook/Authentication/OAuth2Client.php
@@ -38,263 +38,262 @@ use Facebook\Exceptions\FacebookSDKException;
 class OAuth2Client
 {
 
-  /**
-   * @const string The base authorization URL.
-   */
-  const BASE_AUTHORIZATION_URL = 'https://www.facebook.com';
+    /**
+     * @const string The base authorization URL.
+     */
+    const BASE_AUTHORIZATION_URL = 'https://www.facebook.com';
 
-  /**
-   * The FacebookApp entity.
-   *
-   * @var FacebookApp
-   */
-  protected $app;
+    /**
+     * The FacebookApp entity.
+     *
+     * @var FacebookApp
+     */
+    protected $app;
 
-  /**
-   * The Facebook client.
-   *
-   * @var FacebookClient
-   */
-  protected $client;
+    /**
+     * The Facebook client.
+     *
+     * @var FacebookClient
+     */
+    protected $client;
 
-  /**
-   * The version of the Graph API to use.
-   *
-   * @var string
-   */
-  protected $graphVersion;
+    /**
+     * The version of the Graph API to use.
+     *
+     * @var string
+     */
+    protected $graphVersion;
 
-  /**
-   * The last request sent to Graph.
-   *
-   * @var FacebookRequest|null
-   */
-  protected $lastRequest;
+    /**
+     * The last request sent to Graph.
+     *
+     * @var FacebookRequest|null
+     */
+    protected $lastRequest;
 
-  /**
-   * @param FacebookApp $app
-   * @param FacebookClient $client
-   * @param string|null $graphVersion The version of the Graph API to use.
-   */
-  public function __construct(FacebookApp $app, FacebookClient $client, $graphVersion = null)
-  {
-    $this->app = $app;
-    $this->client = $client;
-    $this->graphVersion = $graphVersion ?: Facebook::DEFAULT_GRAPH_VERSION;
-  }
-
-  /**
-   * Returns the last FacebookRequest that was sent.
-   * Useful for debugging and testing.
-   *
-   * @return FacebookRequest|null
-   */
-  public function getLastRequest()
-  {
-    return $this->lastRequest;
-  }
-
-  /**
-   * Get the metadata associated with the access token.
-   *
-   * @param AccessToken|string $accessToken The access token to debug.
-   *
-   * @return AccessTokenMetadata
-   */
-  public function debugToken($accessToken)
-  {
-    $accessToken = $accessToken instanceof AccessToken
-      ? $accessToken->getValue()
-      : $accessToken;
-
-    $params = ['input_token' => $accessToken];
-
-    $this->lastRequest = new FacebookRequest(
-      $this->app,
-      $this->app->getAccessToken(),
-      'GET',
-      '/debug_token',
-      $params,
-      null,
-      $this->graphVersion
-    );
-    $response = $this->client->sendRequest($this->lastRequest);
-    $metadata = $response->getDecodedBody();
-
-    return new AccessTokenMetadata($metadata);
-  }
-
-  /**
-   * Generates an authorization URL to begin the process of authenticating a user.
-   *
-   * @param string $redirectUrl The callback URL to redirect to.
-   * @param array $scope An array of permissions to request.
-   * @param string $state The CSPRNG-generated CSRF value.
-   * @param array $params An array of parameters to generate URL.
-   * @param string $separator The separator to use in http_build_query().
-   *
-   * @return string
-   */
-  public function getAuthorizationUrl($redirectUrl, array $scope = [], $state, array $params = [], $separator = '&')
-  {
-    $params += [
-      'client_id' => $this->app->getId(),
-      'state' => $state,
-      'response_type' => 'code',
-      'sdk' => 'php-sdk-' . Facebook::VERSION,
-      'redirect_uri' => $redirectUrl,
-      'scope' => implode(',', $scope)
-    ];
-
-    return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' .
-            http_build_query($params, null, $separator);
-  }
-
-  /**
-   * Get a valid access token from a code.
-   *
-   * @param string $code
-   * @param string $redirectUri
-   *
-   * @return AccessToken
-   *
-   * @throws FacebookSDKException
-   */
-  public function getAccessTokenFromCode($code, $redirectUri = '')
-  {
-    $params = [
-      'code' => $code,
-      'redirect_uri' => $redirectUri,
-    ];
-
-    return $this->requestAnAccessToken($params);
-  }
-
-  /**
-   * Exchanges a short-lived access token with a long-lived access token.
-   *
-   * @param AccessToken|string $accessToken
-   *
-   * @return AccessToken
-   *
-   * @throws FacebookSDKException
-   */
-  public function getLongLivedAccessToken($accessToken)
-  {
-    $accessToken = $accessToken instanceof AccessToken
-      ? $accessToken->getValue()
-      : $accessToken;
-
-    $params = [
-      'grant_type' => 'fb_exchange_token',
-      'fb_exchange_token' => $accessToken,
-    ];
-
-    return $this->requestAnAccessToken($params);
-  }
-
-  /**
-   * Get a valid code from an access token.
-   *
-   * @param AccessToken|string $accessToken
-   * @param string $redirectUri
-   *
-   * @return AccessToken
-   *
-   * @throws FacebookSDKException
-   */
-  public function getCodeFromLongLivedAccessToken($accessToken, $redirectUri = '')
-  {
-    $params = [
-      'redirect_uri' => $redirectUri,
-    ];
-
-    $response = $this->sendRequestWithClientParams('/oauth/client_code', $params, $accessToken);
-    $data = $response->getDecodedBody();
-
-    if ( ! isset($data['code'])) {
-      throw new FacebookSDKException('Code was not returned from Graph.', 401);
+    /**
+     * @param FacebookApp $app
+     * @param FacebookClient $client
+     * @param string|null $graphVersion The version of the Graph API to use.
+     */
+    public function __construct(FacebookApp $app, FacebookClient $client, $graphVersion = null)
+    {
+        $this->app = $app;
+        $this->client = $client;
+        $this->graphVersion = $graphVersion ?: Facebook::DEFAULT_GRAPH_VERSION;
     }
 
-    return $data['code'];
-  }
-
-  /**
-   * Send a request to the OAuth endpoint.
-   *
-   * @param array $params
-   *
-   * @return AccessToken
-   *
-   * @throws FacebookSDKException
-   */
-  protected function requestAnAccessToken(array $params)
-  {
-    $response = $this->sendRequestWithClientParams('/oauth/access_token', $params);
-    $data = $response->getDecodedBody();
-
-    if ( ! isset($data['access_token'])) {
-      throw new FacebookSDKException('Access token was not returned from Graph.', 401);
+    /**
+     * Returns the last FacebookRequest that was sent.
+     * Useful for debugging and testing.
+     *
+     * @return FacebookRequest|null
+     */
+    public function getLastRequest()
+    {
+        return $this->lastRequest;
     }
 
-    // Graph returns two different key names for expiration time
-    // on the same endpoint. Doh! :/
-    $expiresAt = 0;
-    if (isset($data['expires'])) {
-      // For exchanging a short lived token with a long lived token.
-      // The expiration time in seconds will be returned as "expires".
-      $expiresAt = time() + $data['expires'];
-    } elseif (isset($data['expires_in'])) {
-      // For exchanging a code for a short lived access token.
-      // The expiration time in seconds will be returned as "expires_in".
-      // See: https://developers.facebook.com/docs/facebook-login/access-tokens#long-via-code
-      $expiresAt = time() + $data['expires_in'];
+    /**
+     * Get the metadata associated with the access token.
+     *
+     * @param AccessToken|string $accessToken The access token to debug.
+     *
+     * @return AccessTokenMetadata
+     */
+    public function debugToken($accessToken)
+    {
+        $accessToken = $accessToken instanceof AccessToken
+            ? $accessToken->getValue()
+            : $accessToken;
+
+        $params = ['input_token' => $accessToken];
+
+        $this->lastRequest = new FacebookRequest(
+            $this->app,
+            $this->app->getAccessToken(),
+            'GET',
+            '/debug_token',
+            $params,
+            null,
+            $this->graphVersion
+        );
+        $response = $this->client->sendRequest($this->lastRequest);
+        $metadata = $response->getDecodedBody();
+
+        return new AccessTokenMetadata($metadata);
     }
 
-    return new AccessToken($data['access_token'], $expiresAt);
-  }
+    /**
+     * Generates an authorization URL to begin the process of authenticating a user.
+     *
+     * @param string $redirectUrl The callback URL to redirect to.
+     * @param array $scope An array of permissions to request.
+     * @param string $state The CSPRNG-generated CSRF value.
+     * @param array $params An array of parameters to generate URL.
+     * @param string $separator The separator to use in http_build_query().
+     *
+     * @return string
+     */
+    public function getAuthorizationUrl($redirectUrl, $state, array $scope = [], array $params = [], $separator = '&')
+    {
+        $params += [
+            'client_id' => $this->app->getId(),
+            'state' => $state,
+            'response_type' => 'code',
+            'sdk' => 'php-sdk-' . Facebook::VERSION,
+            'redirect_uri' => $redirectUrl,
+            'scope' => implode(',', $scope)
+        ];
 
-  /**
-   * Send a request to Graph with an app access token.
-   *
-   * @param string $endpoint
-   * @param array $params
-   * @param string|null $accessToken
-   *
-   * @return FacebookResponse
-   *
-   * @throws FacebookResponseException
-   */
-  protected function sendRequestWithClientParams($endpoint, array $params, $accessToken = null)
-  {
-    $params += $this->getClientParams();
+        return static::BASE_AUTHORIZATION_URL . '/' . $this->graphVersion . '/dialog/oauth?' .
+                        http_build_query($params, null, $separator);
+    }
 
-    $accessToken = $accessToken ?: $this->app->getAccessToken();
+    /**
+     * Get a valid access token from a code.
+     *
+     * @param string $code
+     * @param string $redirectUri
+     *
+     * @return AccessToken
+     *
+     * @throws FacebookSDKException
+     */
+    public function getAccessTokenFromCode($code, $redirectUri = '')
+    {
+        $params = [
+            'code' => $code,
+            'redirect_uri' => $redirectUri,
+        ];
 
-    $this->lastRequest = new FacebookRequest(
-      $this->app,
-      $accessToken,
-      'GET',
-      $endpoint,
-      $params,
-      null,
-      $this->graphVersion
-    );
+        return $this->requestAnAccessToken($params);
+    }
 
-    return $this->client->sendRequest($this->lastRequest);
-  }
+    /**
+     * Exchanges a short-lived access token with a long-lived access token.
+     *
+     * @param AccessToken|string $accessToken
+     *
+     * @return AccessToken
+     *
+     * @throws FacebookSDKException
+     */
+    public function getLongLivedAccessToken($accessToken)
+    {
+        $accessToken = $accessToken instanceof AccessToken
+            ? $accessToken->getValue()
+            : $accessToken;
 
-  /**
-   * Returns the client_* params for OAuth requests.
-   *
-   * @return array
-   */
-  protected function getClientParams()
-  {
-    return [
-      'client_id' => $this->app->getId(),
-      'client_secret' => $this->app->getSecret(),
-    ];
-  }
+        $params = [
+            'grant_type' => 'fb_exchange_token',
+            'fb_exchange_token' => $accessToken,
+        ];
 
+        return $this->requestAnAccessToken($params);
+    }
+
+    /**
+     * Get a valid code from an access token.
+     *
+     * @param AccessToken|string $accessToken
+     * @param string $redirectUri
+     *
+     * @return AccessToken
+     *
+     * @throws FacebookSDKException
+     */
+    public function getCodeFromLongLivedAccessToken($accessToken, $redirectUri = '')
+    {
+        $params = [
+            'redirect_uri' => $redirectUri,
+        ];
+
+        $response = $this->sendRequestWithClientParams('/oauth/client_code', $params, $accessToken);
+        $data = $response->getDecodedBody();
+
+        if (! isset($data['code'])) {
+            throw new FacebookSDKException('Code was not returned from Graph.', 401);
+        }
+
+        return $data['code'];
+    }
+
+    /**
+     * Send a request to the OAuth endpoint.
+     *
+     * @param array $params
+     *
+     * @return AccessToken
+     *
+     * @throws FacebookSDKException
+     */
+    protected function requestAnAccessToken(array $params)
+    {
+        $response = $this->sendRequestWithClientParams('/oauth/access_token', $params);
+        $data = $response->getDecodedBody();
+
+        if (! isset($data['access_token'])) {
+            throw new FacebookSDKException('Access token was not returned from Graph.', 401);
+        }
+
+        // Graph returns two different key names for expiration time
+        // on the same endpoint. Doh! :/
+        $expiresAt = 0;
+        if (isset($data['expires'])) {
+            // For exchanging a short lived token with a long lived token.
+            // The expiration time in seconds will be returned as "expires".
+            $expiresAt = time() + $data['expires'];
+        } elseif (isset($data['expires_in'])) {
+            // For exchanging a code for a short lived access token.
+            // The expiration time in seconds will be returned as "expires_in".
+            // See: https://developers.facebook.com/docs/facebook-login/access-tokens#long-via-code
+            $expiresAt = time() + $data['expires_in'];
+        }
+
+        return new AccessToken($data['access_token'], $expiresAt);
+    }
+
+    /**
+     * Send a request to Graph with an app access token.
+     *
+     * @param string $endpoint
+     * @param array $params
+     * @param string|null $accessToken
+     *
+     * @return FacebookResponse
+     *
+     * @throws FacebookResponseException
+     */
+    protected function sendRequestWithClientParams($endpoint, array $params, $accessToken = null)
+    {
+        $params += $this->getClientParams();
+
+        $accessToken = $accessToken ?: $this->app->getAccessToken();
+
+        $this->lastRequest = new FacebookRequest(
+            $this->app,
+            $accessToken,
+            'GET',
+            $endpoint,
+            $params,
+            null,
+            $this->graphVersion
+        );
+
+        return $this->client->sendRequest($this->lastRequest);
+    }
+
+    /**
+     * Returns the client_* params for OAuth requests.
+     *
+     * @return array
+     */
+    protected function getClientParams()
+    {
+        return [
+            'client_id' => $this->app->getId(),
+            'client_secret' => $this->app->getSecret(),
+        ];
+    }
 }

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -43,331 +43,324 @@ use Facebook\Exceptions\FacebookSDKException;
 class FacebookRedirectLoginHelper
 {
 
-  /**
-   * @const int The length of CSRF string to validate the login link.
-   */
-  const CSRF_LENGTH = 32;
+    /**
+     * @const int The length of CSRF string to validate the login link.
+     */
+    const CSRF_LENGTH = 32;
 
-  /**
-   * @var OAuth2Client The OAuth 2.0 client service.
-   */
-  protected $oAuth2Client;
+    /**
+     * @var OAuth2Client The OAuth 2.0 client service.
+     */
+    protected $oAuth2Client;
 
-  /**
-   * @var UrlDetectionInterface The URL detection handler.
-   */
-  protected $urlDetectionHandler;
+    /**
+     * @var UrlDetectionInterface The URL detection handler.
+     */
+    protected $urlDetectionHandler;
 
-  /**
-   * @var PersistentDataInterface The persistent data handler.
-   */
-  protected $persistentDataHandler;
+    /**
+     * @var PersistentDataInterface The persistent data handler.
+     */
+    protected $persistentDataHandler;
 
-  /**
-   * @var PseudoRandomStringGeneratorInterface The cryptographically secure
-   *                                           pseudo-random string generator.
-   */
-  protected $pseudoRandomStringGenerator;
+    /**
+     * @var PseudoRandomStringGeneratorInterface The cryptographically secure
+     *                                           pseudo-random string generator.
+     */
+    protected $pseudoRandomStringGenerator;
 
-  /**
-   * @param OAuth2Client $oAuth2Client The OAuth 2.0 client service.
-   * @param PersistentDataInterface|null $persistentDataHandler The persistent data handler.
-   * @param UrlDetectionInterface|null $urlHandler The URL detection handler.
-   * @param PseudoRandomStringGeneratorInterface|null $prsg The cryptographically secure
-   *                                                        pseudo-random string generator.
-   */
-  public function __construct(OAuth2Client $oAuth2Client,
-                              PersistentDataInterface $persistentDataHandler = null,
-                              UrlDetectionInterface $urlHandler = null,
-                              PseudoRandomStringGeneratorInterface $prsg = null)
-  {
-    $this->oAuth2Client = $oAuth2Client;
-    $this->persistentDataHandler = $persistentDataHandler ?: new FacebookSessionPersistentDataHandler();
-    $this->urlDetectionHandler = $urlHandler ?: new FacebookUrlDetectionHandler();
-    $this->pseudoRandomStringGenerator = $prsg ?: $this->detectPseudoRandomStringGenerator();
-  }
-
-  /**
-   * Returns the persistent data handler.
-   *
-   * @return PersistentDataInterface
-   */
-  public function getPersistentDataHandler()
-  {
-    return $this->persistentDataHandler;
-  }
-
-  /**
-   * Returns the URL detection handler.
-   *
-   * @return UrlDetectionInterface
-   */
-  public function getUrlDetectionHandler()
-  {
-    return $this->urlDetectionHandler;
-  }
-
-  /**
-   * Returns the cryptographically secure pseudo-random string generator.
-   *
-   * @return PseudoRandomStringGeneratorInterface
-   */
-  public function getPseudoRandomStringGenerator()
-  {
-    return $this->pseudoRandomStringGenerator;
-  }
-
-  /**
-   * Detects which pseudo-random string generator to use.
-   *
-   * @return PseudoRandomStringGeneratorInterface
-   *
-   * @throws FacebookSDKException
-   */
-  public function detectPseudoRandomStringGenerator()
-  {
-    // Since openssl_random_pseudo_bytes() can sometimes return non-cryptographically
-    // secure pseudo-random strings (in rare cases), we check for mcrypt_create_iv() first.
-    if(function_exists('mcrypt_create_iv')) {
-      return new McryptPseudoRandomStringGenerator();
-    }
-    if(function_exists('openssl_random_pseudo_bytes')) {
-      return new OpenSslPseudoRandomStringGenerator();
-    }
-    if( ! ini_get('open_basedir') && is_readable('/dev/urandom')) {
-      return new UrandomPseudoRandomStringGenerator();
+    /**
+     * @param OAuth2Client $oAuth2Client The OAuth 2.0 client service.
+     * @param PersistentDataInterface|null $persistentDataHandler The persistent data handler.
+     * @param UrlDetectionInterface|null $urlHandler The URL detection handler.
+     * @param PseudoRandomStringGeneratorInterface|null $prsg The cryptographically secure
+     *                                                        pseudo-random string generator.
+     */
+    public function __construct(OAuth2Client $oAuth2Client, PersistentDataInterface $persistentDataHandler = null, UrlDetectionInterface $urlHandler = null, PseudoRandomStringGeneratorInterface $prsg = null)
+    {
+        $this->oAuth2Client = $oAuth2Client;
+        $this->persistentDataHandler = $persistentDataHandler ?: new FacebookSessionPersistentDataHandler();
+        $this->urlDetectionHandler = $urlHandler ?: new FacebookUrlDetectionHandler();
+        $this->pseudoRandomStringGenerator = $prsg ?: $this->detectPseudoRandomStringGenerator();
     }
 
-    throw new FacebookSDKException(
-      'Unable to detect a cryptographically secure pseudo-random string generator.'
-    );
-  }
-
-  /**
-   * Stores CSRF state and returns a URL to which the user should be sent to
-   *   in order to continue the login process with Facebook.
-   *
-   * @param string $redirectUrl The URL Facebook should redirect users to
-   *                            after login.
-   * @param array $scope List of permissions to request during login.
-   * @param array $params An array of parameters to generate URL.
-   * @param string $separator The separator to use in http_build_query().
-   *
-   * @return string
-   */
-  private function makeUrl($redirectUrl, array $scope, array $params = [], $separator = '&')
-  {
-    $state = $this->pseudoRandomStringGenerator->getPseudoRandomString(static::CSRF_LENGTH);
-    $this->persistentDataHandler->set('state', $state);
-
-    return $this->oAuth2Client->getAuthorizationUrl($redirectUrl, $scope, $state, $params, $separator);
-  }
-
-  /**
-   * Returns the URL to send the user in order to login to Facebook.
-   *
-   * @param string $redirectUrl The URL Facebook should redirect users to
-   *                            after login.
-   * @param array $scope List of permissions to request during login.
-   * @param string $separator The separator to use in http_build_query().
-   *
-   * @return string
-   */
-  public function getLoginUrl($redirectUrl,
-                              array $scope = [],
-                              $separator = '&')
-  {
-    return $this->makeUrl($redirectUrl, $scope, [], $separator);
-  }
-
-  /**
-   * Returns the URL to send the user in order to log out of Facebook.
-   *
-   * @param AccessToken|string $accessToken The access token that will be logged out.
-   * @param string $next The url Facebook should redirect the user to after
-   *                          a successful logout.
-   * @param string $separator The separator to use in http_build_query().
-   *
-   * @return string
-   *
-   * @throws FacebookSDKException
-   */
-  public function getLogoutUrl($accessToken, $next, $separator = '&')
-  {
-    if ( ! $accessToken instanceof AccessToken) {
-      $accessToken = new AccessToken($accessToken);
+    /**
+     * Returns the persistent data handler.
+     *
+     * @return PersistentDataInterface
+     */
+    public function getPersistentDataHandler()
+    {
+        return $this->persistentDataHandler;
     }
 
-    if ($accessToken->isAppAccessToken()) {
-      throw new FacebookSDKException('Cannot generate a logout URL with an app access token.', 722);
+    /**
+     * Returns the URL detection handler.
+     *
+     * @return UrlDetectionInterface
+     */
+    public function getUrlDetectionHandler()
+    {
+        return $this->urlDetectionHandler;
     }
 
-    $params = [
-      'next' => $next,
-      'access_token' => $accessToken->getValue(),
-    ];
-
-    return 'https://www.facebook.com/logout.php?' . http_build_query($params, null, $separator);
-  }
-
-  /**
-   * Returns the URL to send the user in order to login to Facebook with
-   * permission(s) to be re-asked.
-   *
-   * @param string $redirectUrl The URL Facebook should redirect users to
-   *                            after login.
-   * @param array $scope List of permissions to request during login.
-   * @param string $separator The separator to use in http_build_query().
-   *
-   * @return string
-   */
-  public function getReRequestUrl($redirectUrl,
-                                  array $scope = [],
-                                  $separator = '&')
-  {
-    $params = ['auth_type' => 'rerequest'];
-
-    return $this->makeUrl($redirectUrl, $scope, $params, $separator);
-  }
-
-  /**
-   * Returns the URL to send the user in order to login to Facebook with
-   * user to be re-authenticated.
-   *
-   * @param string $redirectUrl The URL Facebook should redirect users to
-   *                            after login.
-   * @param array $scope List of permissions to request during login.
-   * @param string $separator The separator to use in http_build_query().
-   *
-   * @return string
-   */
-  public function getReAuthenticationUrl($redirectUrl,
-                                         array $scope = [],
-                                         $separator = '&')
-  {
-    $params = ['auth_type' => 'reauthenticate'];
-
-    return $this->makeUrl($redirectUrl, $scope, $params, $separator);
-  }
-
-  /**
-   * Takes a valid code from a login redirect, and returns an AccessToken entity.
-   *
-   * @param string|null $redirectUrl The redirect URL.
-   *
-   * @return AccessToken|null
-   *
-   * @throws FacebookSDKException
-   */
-  public function getAccessToken($redirectUrl = null)
-  {
-    if ( ! $code = $this->getCode()) {
-      return null;
+    /**
+     * Returns the cryptographically secure pseudo-random string generator.
+     *
+     * @return PseudoRandomStringGeneratorInterface
+     */
+    public function getPseudoRandomStringGenerator()
+    {
+        return $this->pseudoRandomStringGenerator;
     }
 
-    $this->validateCsrf();
+    /**
+     * Detects which pseudo-random string generator to use.
+     *
+     * @return PseudoRandomStringGeneratorInterface
+     *
+     * @throws FacebookSDKException
+     */
+    public function detectPseudoRandomStringGenerator()
+    {
+        // Since openssl_random_pseudo_bytes() can sometimes return non-cryptographically
+        // secure pseudo-random strings (in rare cases), we check for mcrypt_create_iv() first.
+        if (function_exists('mcrypt_create_iv')) {
+            return new McryptPseudoRandomStringGenerator();
+        }
 
-    $redirectUrl = $redirectUrl ?: $this->urlDetectionHandler->getCurrentUrl();
-    // At minimum we need to remove the state param
-    $redirectUrl = FacebookUrlManipulator::removeParamsFromUrl($redirectUrl, ['state']);
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            return new OpenSslPseudoRandomStringGenerator();
+        }
 
-    return $this->oAuth2Client->getAccessTokenFromCode($code, $redirectUrl);
-  }
+        if (! ini_get('open_basedir') && is_readable('/dev/urandom')) {
+            return new UrandomPseudoRandomStringGenerator();
+        }
 
-  /**
-   * Validate the request against a cross-site request forgery.
-   *
-   * @throws FacebookSDKException
-   */
-  protected function validateCsrf()
-  {
-    $state = $this->getState();
-    $savedState = $this->persistentDataHandler->get('state');
-
-    if ( ! $state || ! $savedState) {
-      throw new FacebookSDKException(
-        'Cross-site request forgery validation failed. ' .
-        'Required param "state" missing.'
-      );
+        throw new FacebookSDKException(
+            'Unable to detect a cryptographically secure pseudo-random string generator.'
+        );
     }
-    if ($state !== $savedState) {
-      throw new FacebookSDKException(
-        'Cross-site request forgery validation failed. ' .
-        'The "state" param from the URL and session do not match.'
-      );
+
+    /**
+     * Stores CSRF state and returns a URL to which the user should be sent to
+     *   in order to continue the login process with Facebook.
+     *
+     * @param string $redirectUrl The URL Facebook should redirect users to
+     *                            after login.
+     * @param array $scope List of permissions to request during login.
+     * @param array $params An array of parameters to generate URL.
+     * @param string $separator The separator to use in http_build_query().
+     *
+     * @return string
+     */
+    private function makeUrl($redirectUrl, array $scope, array $params = [], $separator = '&')
+    {
+        $state = $this->pseudoRandomStringGenerator->getPseudoRandomString(static::CSRF_LENGTH);
+        $this->persistentDataHandler->set('state', $state);
+
+        return $this->oAuth2Client->getAuthorizationUrl($redirectUrl, $state, $scope, $params, $separator);
     }
-  }
 
-  /**
-   * Return the code.
-   *
-   * @return string|null
-   */
-  protected function getCode()
-  {
-    return $this->getInput('code');
-  }
+    /**
+     * Returns the URL to send the user in order to login to Facebook.
+     *
+     * @param string $redirectUrl The URL Facebook should redirect users to
+     *                            after login.
+     * @param array $scope List of permissions to request during login.
+     * @param string $separator The separator to use in http_build_query().
+     *
+     * @return string
+     */
+    public function getLoginUrl($redirectUrl, array $scope = [], $separator = '&')
+    {
+        return $this->makeUrl($redirectUrl, $scope, [], $separator);
+    }
 
-  /**
-   * Return the state.
-   *
-   * @return string|null
-   */
-  protected function getState()
-  {
-    return $this->getInput('state');
-  }
+    /**
+     * Returns the URL to send the user in order to log out of Facebook.
+     *
+     * @param AccessToken|string $accessToken The access token that will be logged out.
+     * @param string $next The url Facebook should redirect the user to after
+     *                          a successful logout.
+     * @param string $separator The separator to use in http_build_query().
+     *
+     * @return string
+     *
+     * @throws FacebookSDKException
+     */
+    public function getLogoutUrl($accessToken, $next, $separator = '&')
+    {
+        if (! $accessToken instanceof AccessToken) {
+            $accessToken = new AccessToken($accessToken);
+        }
 
-  /**
-   * Return the error code.
-   *
-   * @return string|null
-   */
-  public function getErrorCode()
-  {
-    return $this->getInput('error_code');
-  }
+        if ($accessToken->isAppAccessToken()) {
+            throw new FacebookSDKException('Cannot generate a logout URL with an app access token.', 722);
+        }
 
-  /**
-   * Returns the error.
-   *
-   * @return string|null
-   */
-  public function getError()
-  {
-    return $this->getInput('error');
-  }
+        $params = [
+            'next' => $next,
+            'access_token' => $accessToken->getValue(),
+        ];
 
-  /**
-   * Returns the error reason.
-   *
-   * @return string|null
-   */
-  public function getErrorReason()
-  {
-    return $this->getInput('error_reason');
-  }
+        return 'https://www.facebook.com/logout.php?' . http_build_query($params, null, $separator);
+    }
 
-  /**
-   * Returns the error description.
-   *
-   * @return string|null
-   */
-  public function getErrorDescription()
-  {
-    return $this->getInput('error_description');
-  }
+    /**
+     * Returns the URL to send the user in order to login to Facebook with
+     * permission(s) to be re-asked.
+     *
+     * @param string $redirectUrl The URL Facebook should redirect users to
+     *                            after login.
+     * @param array $scope List of permissions to request during login.
+     * @param string $separator The separator to use in http_build_query().
+     *
+     * @return string
+     */
+    public function getReRequestUrl($redirectUrl, array $scope = [], $separator = '&')
+    {
+        $params = ['auth_type' => 'rerequest'];
 
-  /**
-   * Returns a value from a GET param.
-   *
-   * @param string $key
-   *
-   * @return string|null
-   */
-  private function getInput($key)
-  {
-    return isset($_GET[$key]) ? $_GET[$key] : null;
-  }
+        return $this->makeUrl($redirectUrl, $scope, $params, $separator);
+    }
 
+    /**
+     * Returns the URL to send the user in order to login to Facebook with
+     * user to be re-authenticated.
+     *
+     * @param string $redirectUrl The URL Facebook should redirect users to
+     *                            after login.
+     * @param array $scope List of permissions to request during login.
+     * @param string $separator The separator to use in http_build_query().
+     *
+     * @return string
+     */
+    public function getReAuthenticationUrl($redirectUrl, array $scope = [], $separator = '&')
+    {
+        $params = ['auth_type' => 'reauthenticate'];
+
+        return $this->makeUrl($redirectUrl, $scope, $params, $separator);
+    }
+
+    /**
+     * Takes a valid code from a login redirect, and returns an AccessToken entity.
+     *
+     * @param string|null $redirectUrl The redirect URL.
+     *
+     * @return AccessToken|null
+     *
+     * @throws FacebookSDKException
+     */
+    public function getAccessToken($redirectUrl = null)
+    {
+        if (! $code = $this->getCode()) {
+            return null;
+        }
+
+        $this->validateCsrf();
+
+        $redirectUrl = $redirectUrl ?: $this->urlDetectionHandler->getCurrentUrl();
+        // At minimum we need to remove the state param
+        $redirectUrl = FacebookUrlManipulator::removeParamsFromUrl($redirectUrl, ['state']);
+
+        return $this->oAuth2Client->getAccessTokenFromCode($code, $redirectUrl);
+    }
+
+    /**
+     * Validate the request against a cross-site request forgery.
+     *
+     * @throws FacebookSDKException
+     */
+    protected function validateCsrf()
+    {
+        $state = $this->getState();
+        $savedState = $this->persistentDataHandler->get('state');
+
+        if (! $state || ! $savedState) {
+            throw new FacebookSDKException(
+                'Cross-site request forgery validation failed. ' .
+                'Required param "state" missing.'
+            );
+        }
+        
+        if ($state !== $savedState) {
+            throw new FacebookSDKException(
+                'Cross-site request forgery validation failed. ' .
+                'The "state" param from the URL and session do not match.'
+            );
+        }
+    }
+
+    /**
+     * Return the code.
+     *
+     * @return string|null
+     */
+    protected function getCode()
+    {
+        return $this->getInput('code');
+    }
+
+    /**
+     * Return the state.
+     *
+     * @return string|null
+     */
+    protected function getState()
+    {
+        return $this->getInput('state');
+    }
+
+    /**
+     * Return the error code.
+     *
+     * @return string|null
+     */
+    public function getErrorCode()
+    {
+        return $this->getInput('error_code');
+    }
+
+    /**
+     * Returns the error.
+     *
+     * @return string|null
+     */
+    public function getError()
+    {
+        return $this->getInput('error');
+    }
+
+    /**
+     * Returns the error reason.
+     *
+     * @return string|null
+     */
+    public function getErrorReason()
+    {
+        return $this->getInput('error_reason');
+    }
+
+    /**
+     * Returns the error description.
+     *
+     * @return string|null
+     */
+    public function getErrorDescription()
+    {
+        return $this->getInput('error_description');
+    }
+
+    /**
+     * Returns a value from a GET param.
+     *
+     * @param string $key
+     *
+     * @return string|null
+     */
+    private function getInput($key)
+    {
+        return isset($_GET[$key]) ? $_GET[$key] : null;
+    }
 }

--- a/tests/Authentication/AccessTokenMetadata.php
+++ b/tests/Authentication/AccessTokenMetadata.php
@@ -28,112 +28,111 @@ use Facebook\Authentication\AccessTokenMetadata;
 class AccessTokenMetadataTest extends \PHPUnit_Framework_TestCase
 {
 
-  protected $graphResponseData = [
-    'data' => [
-      'app_id' => '123',
-      'application' => 'Foo App',
-      'error' => [
-        'code' => 190,
-        'message' => 'Foo error message.',
-        'subcode' => 463,
-      ],
-      'issued_at' => 1422110200,
-      'expires_at' => 1422115200,
-      'is_valid' => false,
-      'metadata' => [
-        'sso' => 'iphone-sso',
-        'auth_type' => 'rerequest',
-        'auth_nonce' => 'no-replicatey',
-      ],
-      'scopes' => ['public_profile', 'basic_info', 'user_friends'],
-      'profile_id' => '1000',
-      'user_id' => '1337',
-    ],
-  ];
+    protected $graphResponseData = [
+        'data' => [
+            'app_id' => '123',
+            'application' => 'Foo App',
+            'error' => [
+                'code' => 190,
+                'message' => 'Foo error message.',
+                'subcode' => 463,
+            ],
+            'issued_at' => 1422110200,
+            'expires_at' => 1422115200,
+            'is_valid' => false,
+            'metadata' => [
+                'sso' => 'iphone-sso',
+                'auth_type' => 'rerequest',
+                'auth_nonce' => 'no-replicatey',
+            ],
+            'scopes' => ['public_profile', 'basic_info', 'user_friends'],
+            'profile_id' => '1000',
+            'user_id' => '1337',
+        ],
+    ];
 
-  public function testDatesGetCastToDateTime()
-  {
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
+    public function testDatesGetCastToDateTime()
+    {
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
 
-    $expires = $metadata->getExpiresAt();
-    $issuedAt = $metadata->getIssuedAt();
+        $expires = $metadata->getExpiresAt();
+        $issuedAt = $metadata->getIssuedAt();
 
-    $this->assertInstanceOf('DateTime', $expires);
-    $this->assertInstanceOf('DateTime', $issuedAt);
-  }
+        $this->assertInstanceOf('DateTime', $expires);
+        $this->assertInstanceOf('DateTime', $issuedAt);
+    }
 
-  public function testAllTheGettersReturnTheProperValue()
-  {
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
+    public function testAllTheGettersReturnTheProperValue()
+    {
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
 
-    $this->assertEquals('123', $metadata->getAppId());
-    $this->assertEquals('Foo App', $metadata->getApplication());
-    $this->assertTrue($metadata->isError(), 'Expected an error');
-    $this->assertEquals('190', $metadata->getErrorCode());
-    $this->assertEquals('Foo error message.', $metadata->getErrorMessage());
-    $this->assertEquals('463', $metadata->getErrorSubcode());
-    $this->assertFalse($metadata->getIsValid(), 'Expected the access token to not be valid');
-    $this->assertEquals('iphone-sso', $metadata->getSso());
-    $this->assertEquals('rerequest', $metadata->getAuthType());
-    $this->assertEquals('no-replicatey', $metadata->getAuthNonce());
-    $this->assertEquals('1000', $metadata->getProfileId());
-    $this->assertEquals(['public_profile', 'basic_info', 'user_friends'], $metadata->getScopes());
-    $this->assertEquals('1337', $metadata->getUserId());
-  }
+        $this->assertEquals('123', $metadata->getAppId());
+        $this->assertEquals('Foo App', $metadata->getApplication());
+        $this->assertTrue($metadata->isError(), 'Expected an error');
+        $this->assertEquals('190', $metadata->getErrorCode());
+        $this->assertEquals('Foo error message.', $metadata->getErrorMessage());
+        $this->assertEquals('463', $metadata->getErrorSubcode());
+        $this->assertFalse($metadata->getIsValid(), 'Expected the access token to not be valid');
+        $this->assertEquals('iphone-sso', $metadata->getSso());
+        $this->assertEquals('rerequest', $metadata->getAuthType());
+        $this->assertEquals('no-replicatey', $metadata->getAuthNonce());
+        $this->assertEquals('1000', $metadata->getProfileId());
+        $this->assertEquals(['public_profile', 'basic_info', 'user_friends'], $metadata->getScopes());
+        $this->assertEquals('1337', $metadata->getUserId());
+    }
 
-  /**
-   * @expectedException \Facebook\Exceptions\FacebookSDKException
-   */
-  public function testInvalidMetadataWillThrow()
-  {
-    new AccessTokenMetadata(['foo' => 'bar']);
-  }
+    /**
+     * @expectedException \Facebook\Exceptions\FacebookSDKException
+     */
+    public function testInvalidMetadataWillThrow()
+    {
+        new AccessTokenMetadata(['foo' => 'bar']);
+    }
 
-  public function testAnExpectedAppIdWillNotThrow()
-  {
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
-    $metadata->validateAppId('123');
-  }
+    public function testAnExpectedAppIdWillNotThrow()
+    {
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
+        $metadata->validateAppId('123');
+    }
 
-  /**
-   * @expectedException \Facebook\Exceptions\FacebookSDKException
-   */
-  public function testAnUnexpectedAppIdWillThrow()
-  {
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
-    $metadata->validateAppId('foo');
-  }
+    /**
+     * @expectedException \Facebook\Exceptions\FacebookSDKException
+     */
+    public function testAnUnexpectedAppIdWillThrow()
+    {
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
+        $metadata->validateAppId('foo');
+    }
 
-  public function testAnExpectedUserIdWillNotThrow()
-  {
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
-    $metadata->validateUserId('1337');
-  }
+    public function testAnExpectedUserIdWillNotThrow()
+    {
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
+        $metadata->validateUserId('1337');
+    }
 
-  /**
-   * @expectedException \Facebook\Exceptions\FacebookSDKException
-   */
-  public function testAnUnexpectedUserIdWillThrow()
-  {
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
-    $metadata->validateUserId('foo');
-  }
+    /**
+     * @expectedException \Facebook\Exceptions\FacebookSDKException
+     */
+    public function testAnUnexpectedUserIdWillThrow()
+    {
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
+        $metadata->validateUserId('foo');
+    }
 
-  public function testAnActiveAccessTokenWillNotThrow()
-  {
-    $this->graphResponseData['data']['expires_at'] = time() + 1000;
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
-    $metadata->validateExpiration();
-  }
+    public function testAnActiveAccessTokenWillNotThrow()
+    {
+        $this->graphResponseData['data']['expires_at'] = time() + 1000;
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
+        $metadata->validateExpiration();
+    }
 
-  /**
-   * @expectedException \Facebook\Exceptions\FacebookSDKException
-   */
-  public function testAnExpiredAccessTokenWillThrow()
-  {
-    $this->graphResponseData['data']['expires_at'] = time() - 1000;
-    $metadata = new AccessTokenMetadata($this->graphResponseData);
-    $metadata->validateExpiration();
-  }
-
+    /**
+     * @expectedException \Facebook\Exceptions\FacebookSDKException
+     */
+    public function testAnExpiredAccessTokenWillThrow()
+    {
+        $this->graphResponseData['data']['expires_at'] = time() - 1000;
+        $metadata = new AccessTokenMetadata($this->graphResponseData);
+        $metadata->validateExpiration();
+    }
 }

--- a/tests/Authentication/AccessTokenTest.php
+++ b/tests/Authentication/AccessTokenTest.php
@@ -28,85 +28,84 @@ use Facebook\Authentication\AccessToken;
 class AccessTokenTest extends \PHPUnit_Framework_TestCase
 {
 
-  public function testAnAccessTokenCanBeReturnedAsAString()
-  {
-    $accessToken = new AccessToken('foo_token');
+    public function testAnAccessTokenCanBeReturnedAsAString()
+    {
+        $accessToken = new AccessToken('foo_token');
 
-    $this->assertEquals('foo_token', $accessToken->getValue());
-    $this->assertEquals('foo_token', (string) $accessToken);
-  }
+        $this->assertEquals('foo_token', $accessToken->getValue());
+        $this->assertEquals('foo_token', (string) $accessToken);
+    }
 
-  public function testAnAppSecretProofWillBeProperlyGenerated()
-  {
-    $accessToken = new AccessToken('foo_token');
+    public function testAnAppSecretProofWillBeProperlyGenerated()
+    {
+        $accessToken = new AccessToken('foo_token');
 
-    $appSecretProof = $accessToken->getAppSecretProof('shhhhh!is.my.secret');
+        $appSecretProof = $accessToken->getAppSecretProof('shhhhh!is.my.secret');
 
-    $this->assertEquals('796ba0d8a6b339e476a7b166a9e8ac0a395f7de736dc37de5f2f4397f5854eb8', $appSecretProof);
-  }
+        $this->assertEquals('796ba0d8a6b339e476a7b166a9e8ac0a395f7de736dc37de5f2f4397f5854eb8', $appSecretProof);
+    }
 
-  public function testAnAppAccessTokenCanBeDetected()
-  {
-    $normalToken = new AccessToken('foo_token');
-    $isNormalToken = $normalToken->isAppAccessToken();
+    public function testAnAppAccessTokenCanBeDetected()
+    {
+        $normalToken = new AccessToken('foo_token');
+        $isNormalToken = $normalToken->isAppAccessToken();
 
-    $this->assertFalse($isNormalToken, 'Normal access token not expected to look like an app access token.');
+        $this->assertFalse($isNormalToken, 'Normal access token not expected to look like an app access token.');
 
-    $appToken = new AccessToken('123|secret');
-    $isAppToken = $appToken->isAppAccessToken();
+        $appToken = new AccessToken('123|secret');
+        $isAppToken = $appToken->isAppAccessToken();
 
-    $this->assertTrue($isAppToken, 'App access token expected to look like an app access token.');
-  }
+        $this->assertTrue($isAppToken, 'App access token expected to look like an app access token.');
+    }
 
-  public function testShortLivedAccessTokensCanBeDetected()
-  {
-    $anHourAndAHalf = time() + (1.5 * 60);
-    $accessToken = new AccessToken('foo_token', $anHourAndAHalf);
+    public function testShortLivedAccessTokensCanBeDetected()
+    {
+        $anHourAndAHalf = time() + (1.5 * 60);
+        $accessToken = new AccessToken('foo_token', $anHourAndAHalf);
 
-    $isLongLived = $accessToken->isLongLived();
+        $isLongLived = $accessToken->isLongLived();
 
-    $this->assertFalse($isLongLived, 'Expected access token to be short lived.');
-  }
+        $this->assertFalse($isLongLived, 'Expected access token to be short lived.');
+    }
 
-  public function testLongLivedAccessTokensCanBeDetected()
-  {
-    $accessToken = new AccessToken('foo_token', $this->aWeekFromNow());
+    public function testLongLivedAccessTokensCanBeDetected()
+    {
+        $accessToken = new AccessToken('foo_token', $this->aWeekFromNow());
 
-    $isLongLived = $accessToken->isLongLived();
+        $isLongLived = $accessToken->isLongLived();
 
-    $this->assertTrue($isLongLived, 'Expected access token to be long lived.');
-  }
+        $this->assertTrue($isLongLived, 'Expected access token to be long lived.');
+    }
 
-  public function testAnAppAccessTokenDoesNotExpire()
-  {
-    $appToken = new AccessToken('123|secret');
-    $hasExpired = $appToken->isExpired();
+    public function testAnAppAccessTokenDoesNotExpire()
+    {
+        $appToken = new AccessToken('123|secret');
+        $hasExpired = $appToken->isExpired();
 
-    $this->assertFalse($hasExpired, 'App access token not expected to expire.');
-  }
+        $this->assertFalse($hasExpired, 'App access token not expected to expire.');
+    }
 
-  public function testAnAccessTokenCanExpire()
-  {
-    $expireTime = time() - 100;
-    $appToken = new AccessToken('foo_token', $expireTime);
-    $hasExpired = $appToken->isExpired();
+    public function testAnAccessTokenCanExpire()
+    {
+        $expireTime = time() - 100;
+        $appToken = new AccessToken('foo_token', $expireTime);
+        $hasExpired = $appToken->isExpired();
 
-    $this->assertTrue($hasExpired, 'Expected 100 second old access token to be expired.');
-  }
+        $this->assertTrue($hasExpired, 'Expected 100 second old access token to be expired.');
+    }
 
-  public function testAccessTokenCanBeSerialized()
-  {
-    $accessToken = new AccessToken('foo', time(), 'bar');
+    public function testAccessTokenCanBeSerialized()
+    {
+        $accessToken = new AccessToken('foo', time(), 'bar');
 
-    $newAccessToken = unserialize(serialize($accessToken));
+        $newAccessToken = unserialize(serialize($accessToken));
 
-    $this->assertEquals((string) $accessToken, (string) $newAccessToken);
-    $this->assertEquals($accessToken->getExpiresAt(), $newAccessToken->getExpiresAt());
-  }
+        $this->assertEquals((string) $accessToken, (string) $newAccessToken);
+        $this->assertEquals($accessToken->getExpiresAt(), $newAccessToken->getExpiresAt());
+    }
 
-  private function aWeekFromNow()
-  {
-    return time() + (60 * 60 * 24 * 7);//a week from now
-  }
-
+    private function aWeekFromNow()
+    {
+        return time() + (60 * 60 * 24 * 7);//a week from now
+    }
 }

--- a/tests/Authentication/FooFacebookClientForOAuth2Test.php
+++ b/tests/Authentication/FooFacebookClientForOAuth2Test.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\Authentication;
+
+use Facebook\FacebookClient;
+use Facebook\FacebookRequest;
+use Facebook\FacebookResponse;
+
+class FooFacebookClientForOAuth2Test extends FacebookClient
+{
+    protected $response = '';
+
+    public function setMetadataResponse()
+    {
+        $this->response = '{"data":{"user_id":"444"}}';
+    }
+
+    public function setAccessTokenResponse()
+    {
+        $this->response = '{"access_token":"my_access_token","expires":"1422115200"}';
+    }
+
+    public function setCodeResponse()
+    {
+        $this->response = '{"code":"my_neat_code"}';
+    }
+
+    public function sendRequest(FacebookRequest $request)
+    {
+        return new FacebookResponse(
+            $request,
+            $this->response,
+            200,
+            []
+        );
+    }
+}


### PR DESCRIPTION
Most of the changes here are simple fixes (e.g., indenting), but I also had to switch the order of the $state and $scope arguments of the OAuth2Client::getAuthorizationUrl() method, in order to comply with the rule that optional arguments must be at the end of the argument list, and then I updated its callers. 