### PR TITLE
Fix for invalid PHP syntax

### DIFF
--- a/src/Facebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
@@ -32,8 +32,8 @@ class OpenSslPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
     /**
      * @const string The error message when generating the string fails.
      */
-    const ERROR_MESSAGE = 'Unable to generate a cryptographically secure '
-        .'pseudo-random string from openssl_random_pseudo_bytes(). ';
+    const ERROR_MESSAGE =
+      'Unable to generate a cryptographically secure pseudo-random string from openssl_random_pseudo_bytes(). ';
 
     /**
      * @throws FacebookSDKException


### PR DESCRIPTION
This was causing the tests to fail. You can't concatenate string on a constant.

Now that we have Travis CI, we should make sure the tests are passing before merging in a PR. :)