### PR TITLE
Fix for PHP Strict Error

### DIFF
--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -218,7 +218,8 @@ class FacebookRequest
    */
   protected function getRequestURL()
   {
-    $lastInPath = end(explode('/', $this->path));
+    $explodedPath = explode('/', $this->path));
+    $lastInPath = end($explodedPath);
     if ($lastInPath == 'videos' && $this->method === 'POST') {
       $baseUrl = static::BASE_VIDEO_GRAPH_URL;
     } else {

--- a/src/Facebook/FacebookRequest.php
+++ b/src/Facebook/FacebookRequest.php
@@ -218,7 +218,7 @@ class FacebookRequest
    */
   protected function getRequestURL()
   {
-    $explodedPath = explode('/', $this->path));
+    $explodedPath = explode('/', $this->path);
     $lastInPath = end($explodedPath);
     if ($lastInPath == 'videos' && $this->method === 'POST') {
       $baseUrl = static::BASE_VIDEO_GRAPH_URL;


### PR DESCRIPTION
Tested on both PHP 5.4.29 and PHP 5.5.13, the previous code would always return an error of: "Strict Standards: Only variables should be passed by reference in <phpsdk>/src/Facebook/FacebookRequest.php on line 221"

This version fixes the issue and has been tested on PHP 5.4.29.