### PR TITLE
Fixed auto-load prefix

### DIFF
--- a/src/Facebook/autoload.php
+++ b/src/Facebook/autoload.php
@@ -44,7 +44,7 @@ if (version_compare(PHP_VERSION, '5.4.0', '<')) {
  */
 spl_autoload_register(function ($class) {
     // project-specific namespace prefix
-    $prefix = '\Facebook\\';
+    $prefix = 'Facebook\\';
 
     // base directory for the namespace prefix
     $base_dir = defined('FACEBOOK_SDK_V4_SRC_DIR') ? FACEBOOK_SDK_V4_SRC_DIR : __DIR__ . '/';


### PR DESCRIPTION
The extra ```\``` is causing the ```strncmp``` check to fail, resulting in Fatal Errors.