### PR TITLE
revert interface change

### DIFF
--- a/src/Facebook/HttpClients/FacebookCurlHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookCurlHttpClient.php
@@ -141,7 +141,7 @@ class FacebookCurlHttpClient implements FacebookHttpable
    *
    * @throws \Facebook\FacebookSDKException
    */
-  public function send($url, $method = 'GET', array $parameters = array())
+  public function send($url, $method = 'GET', $parameters = array())
   {
     $this->openConnection($url, $method, $parameters);
     $this->tryToSendRequest();

--- a/src/Facebook/HttpClients/FacebookGuzzleHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookGuzzleHttpClient.php
@@ -101,7 +101,7 @@ class FacebookGuzzleHttpClient implements FacebookHttpable {
    *
    * @throws \Facebook\FacebookSDKException
    */
-  public function send($url, $method = 'GET', array $parameters = array())
+  public function send($url, $method = 'GET', $parameters = array())
   {
     $options = array();
     if ($parameters) {

--- a/src/Facebook/HttpClients/FacebookHttpable.php
+++ b/src/Facebook/HttpClients/FacebookHttpable.php
@@ -63,6 +63,6 @@ interface FacebookHttpable
    *
    * @throws \Facebook\FacebookSDKException
    */
-  public function send($url, $method = 'GET', array $parameters = array());
+  public function send($url, $method = 'GET', $parameters = array());
 
 }

--- a/src/Facebook/HttpClients/FacebookStreamHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookStreamHttpClient.php
@@ -97,7 +97,7 @@ class FacebookStreamHttpClient implements FacebookHttpable {
    *
    * @throws \Facebook\FacebookSDKException
    */
-  public function send($url, $method = 'GET', array $parameters = array())
+  public function send($url, $method = 'GET', $parameters = array())
   {
     $options = array(
       'http' => array(


### PR DESCRIPTION
You made a breaking change to an interface in a minor patch library fix (`4.0.16` → `4.0.17`). This fucks up any library implementing this interface. According to [semantic versioning](http://semver.org) this should be a major version bump, so I suggest reverting this change.