### PR TITLE
Update UrandomPseudoRandomStringGenerator.php

### DIFF
--- a/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
@@ -69,6 +69,7 @@ class UrandomPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
                 'Unable to open stream to /dev/urandom.'
             );
         }
+        stream_set_read_buffer($stream, 0);
 
         $binaryString = fread($stream, $length);
         fclose($stream);


### PR DESCRIPTION
Prevent `fread()` from wastefully buffering 8192 bytes from `/dev/urandom`.