### PR TITLE
fix: validate state

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -174,7 +174,6 @@ class FacebookRedirectLoginHelper
    */
   public function getSessionFromRedirect()
   {
-    $this->loadState();
     if ($this->isValidRedirect()) {
       $params = array(
         'client_id' => FacebookSession::_getTargetAppId($this->appId),
@@ -203,7 +202,7 @@ class FacebookRedirectLoginHelper
    */
   protected function isValidRedirect()
   {
-    $savedState = $this->state;
+    $savedState = $this->loadState();
     if (!$this->getCode() || !isset($_GET['state'])) {
       return false;
     }

--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -203,7 +203,7 @@ class FacebookRedirectLoginHelper
    */
   protected function isValidRedirect()
   {
-    $savedState = $this->getCode();
+    $savedState = $this->state;
     if (!$this->getCode() || !isset($_GET['state'])) {
       return false;
     }


### PR DESCRIPTION
After updating to 4.0.19, the isValidRedirect function didn't work right. The wrong variables were checked against each other.