### PR TITLE
[4.1] Fix HHVM bug

### DIFF
--- a/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
+++ b/src/Facebook/PseudoRandomString/UrandomPseudoRandomStringGenerator.php
@@ -69,7 +69,10 @@ class UrandomPseudoRandomStringGenerator implements PseudoRandomStringGeneratorI
                 'Unable to open stream to /dev/urandom.'
             );
         }
-        stream_set_read_buffer($stream, 0);
+
+        if (!defined('HHVM_VERSION')) {
+            stream_set_read_buffer($stream, 0);
+        }
 
         $binaryString = fread($stream, $length);
         fclose($stream);


### PR DESCRIPTION
The `stream_set_read_buffer()` function is [not supported on HHVM](http://docs.hhvm.com/manual/en/function.stream-set-read-buffer.php) and is causing the [tests to fail on Travis-CI](https://travis-ci.org/facebook/facebook-php-sdk-v4/jobs/52794560#L180). This is the fix. :)