### PR TITLE
[4.1] Add Travis-CI check for PHP 7.0 & other changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,21 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false
 
 before_install:
-  - composer self-update
+  - travis_retry composer self-update
 
 install:
-  - composer install --prefer-source --no-interaction
+  - travis_retry composer install --prefer-source --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-text --exclude-group integration
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: 7.0
   fast_finish: true


### PR DESCRIPTION
- Added Travis-CI check for PHP 7.0 since that's [gonna be thing soon](https://wiki.php.net/rfc/php7timeline#proposal). I've got `allow_failures` on so it won't cause the whole build to fail.
- Removed `allow_failures` for HHVM (because hey - you're Facebook and your PHP SDK should run on your flavor of PHP!) :P
- Added `travis_retry` wrapper to `composer` commands so that it'll [retry on timeouts](http://docs.travis-ci.com/user/build-timeouts/).