### PR TITLE
Use bin-dir configuration of composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ composer.phar
 .DS_Store
 .idea/
 tests/FacebookTestCredentials.php
+bin/
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and edit it to add your credentials.
 3) The tests can be executed by running this command from the root directory:
 
 ```bash
-./vendor/bin/phpunit
+./bin/phpunit
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
         "mockery/mockery": "dev-master",
         "guzzlehttp/guzzle": "~4.0"
     },
+    "config": {
+        "bin-dir": "bin"
+    },
     "suggest": {
         "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client"
     },


### PR DESCRIPTION
Composer allows to set up a bin-dir configuration for [vendor binaries](https://getcomposer.org/doc/articles/vendor-binaries.md#can-vendor-binaries-be-installed-somewhere-other-than-vendor-bin-).

I find it easier to run binaries when they are at the root of the project (instead of being buried in the vendor/ directory).

Thus, the tests can be run with just `bin/phpunit` instead of `vendor/bin/phpunit`
