### PR TITLE
[4.0] Fix for multidimensional params support

### DIFF
--- a/src/Facebook/HttpClients/FacebookCurlHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookCurlHttpClient.php
@@ -181,7 +181,7 @@ class FacebookCurlHttpClient implements FacebookHttpable
     );
 
     if ($method !== 'GET') {
-      $options[CURLOPT_POSTFIELDS] = $parameters;
+      $options[CURLOPT_POSTFIELDS] = !$this->paramsHaveFile($parameters) ? http_build_query($parameters, null, '&') : $parameters;
     }
     if ($method === 'DELETE' || $method === 'PUT') {
       $options[CURLOPT_CUSTOMREQUEST] = $method;
@@ -324,6 +324,24 @@ class FacebookCurlHttpClient implements FacebookHttpable
     $version = $ver['version_number'];
 
     return $version < self::CURL_PROXY_QUIRK_VER;
+  }
+
+  /**
+   * Detect if the params have a file to upload.
+   *
+   * @param array $params
+   *
+   * @return boolean
+   */
+  private function paramsHaveFile(array $params)
+  {
+    foreach ($params as $value) {
+      if ($value instanceof \CURLFile) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
 }


### PR DESCRIPTION
I went in to debug #383 and found that the 4.0 tests were failing out of the box. This PR:

1. Fixes the tests.
2. Removes the PUT test as PUT is not supported by the Graph API.
3. Adds support for multidimensional params and a multidimensional param test.

This is just a hack to get multidimensional param support without rewriting all the HTTP client stuffs like we did in 4.1. :)