### PR TITLE
[4.1] Graph version bump to v2.3

### DIFF
--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -62,7 +62,7 @@ class Facebook
     /**
      * @const string Default Graph API version for requests.
      */
-    const DEFAULT_GRAPH_VERSION = 'v2.2';
+    const DEFAULT_GRAPH_VERSION = 'v2.3';
 
     /**
      * @const string The name of the environment variable that contains the app ID.


### PR DESCRIPTION
Bumps fallback Graph version to v2.3.

Going to be proposing removing this fallback completely in v4.2 and throwing an error if the `default_graph_version` option is not supplied. :)