### PR TITLE
Support setting base directory with or without the trailing slash

### DIFF
--- a/src/Facebook/autoload.php
+++ b/src/Facebook/autoload.php
@@ -62,7 +62,7 @@ spl_autoload_register(function ($class) {
     // replace the namespace prefix with the base directory, replace namespace
     // separators with directory separators in the relative class name, append
     // with .php
-    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+    $file = rtrim($base_dir, '/') . '/' . str_replace('\\', '/', $relative_class) . '.php';
 
     // if the file exists, require it
     if (file_exists($file)) {


### PR DESCRIPTION
These both work the same
``` php
define('FACEBOOK_SDK_V4_SRC_DIR', 'path/to/Facebook/');
// OR
define('FACEBOOK_SDK_V4_SRC_DIR', 'path/to/Facebook');
```