### PR TITLE
[4.1][Fix] Add support for nested params for multipart requests

### DIFF
--- a/src/Facebook/Http/RequestBodyMultipart.php
+++ b/src/Facebook/Http/RequestBodyMultipart.php
@@ -39,17 +39,17 @@ class RequestBodyMultipart implements RequestBodyInterface
     /**
      * @var string The boundary.
      */
-    protected $boundary;
+    private $boundary;
 
     /**
      * @var array The parameters to send with this request.
      */
-    protected $params = [];
+    private $params;
 
     /**
      * @var array The files to send with this request.
      */
-    protected $files = [];
+    private $files = [];
 
     /**
      * @param array  $params   The parameters to send with this request.
@@ -71,7 +71,8 @@ class RequestBodyMultipart implements RequestBodyInterface
         $body = '';
 
         // Compile normal params
-        foreach ($this->params as $k => $v) {
+        $params = $this->getNestedParams($this->params);
+        foreach ($params as $k => $v) {
             $body .= $this->getParamString($k, $v);
         }
 
@@ -132,6 +133,27 @@ class RequestBodyMultipart implements RequestBodyInterface
             $name,
             $value
         );
+    }
+
+    /**
+     * Returns the params as an array of nested params.
+     *
+     * @param array $params
+     *
+     * @return array
+     */
+    private function getNestedParams(array $params)
+    {
+        $query = http_build_query($params, null, '&');
+        $params = explode('&', $query);
+        $result = [];
+
+        foreach ($params as $param) {
+            list($key, $value) = explode('=', $param, 2);
+            $result[urldecode($key)] = urldecode($value);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Http/RequestBodyMultipartTest.php
+++ b/tests/Http/RequestBodyMultipartTest.php
@@ -64,4 +64,48 @@ class RequestBodyMultipartTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedBody, $body);
     }
+
+    public function testSupportsMultidimensionalParams()
+    {
+        $message = new RequestBodyMultipart([
+          'foo' => 'bar',
+          'faz' => [1,2,3],
+          'targeting' => [
+            'countries' => 'US,GB',
+            'age_min' => 13,
+          ],
+          'call_to_action' => [
+            'type' => 'LEARN_MORE',
+            'value' => [
+              'link' => 'http://example.com',
+              'sponsorship' => [
+                'image' => 'http://example.com/bar.jpg',
+              ],
+            ],
+          ],
+        ], [], 'foo_boundary');
+        $body = $message->getBody();
+
+        $expectedBody = "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"foo\"\r\n\r\nbar\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"faz[0]\"\r\n\r\n1\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"faz[1]\"\r\n\r\n2\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"faz[2]\"\r\n\r\n3\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"targeting[countries]\"\r\n\r\nUS,GB\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"targeting[age_min]\"\r\n\r\n13\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"call_to_action[type]\"\r\n\r\nLEARN_MORE\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"call_to_action[value][link]\"\r\n\r\nhttp://example.com\r\n";
+        $expectedBody .= "--foo_boundary\r\n";
+        $expectedBody .= "Content-Disposition: form-data; name=\"call_to_action[value][sponsorship][image]\"\r\n\r\nhttp://example.com/bar.jpg\r\n";
+        $expectedBody .= "--foo_boundary--\r\n";
+
+        $this->assertEquals($expectedBody, $body);
+    }
 }

--- a/tests/Http/RequestUrlEncodedTest.php
+++ b/tests/Http/RequestUrlEncodedTest.php
@@ -37,4 +37,28 @@ class RequestUrlEncodedTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo=bar&scawy_vawues=%40FooBar+is+a+real+twitter+handle.', $body);
     }
+
+    public function testSupportsMultidimensionalParams()
+    {
+        $message = new RequestBodyUrlEncoded([
+            'foo' => 'bar',
+            'faz' => [1,2,3],
+            'targeting' => [
+              'countries' => 'US,GB',
+              'age_min' => 13,
+            ],
+            'call_to_action' => [
+              'type' => 'LEARN_MORE',
+              'value' => [
+                'link' => 'http://example.com',
+                'sponsorship' => [
+                  'image' => 'http://example.com/bar.jpg',
+                ],
+              ],
+            ],
+        ]);
+        $body = $message->getBody();
+
+        $this->assertEquals('foo=bar&faz%5B0%5D=1&faz%5B1%5D=2&faz%5B2%5D=3&targeting%5Bcountries%5D=US%2CGB&targeting%5Bage_min%5D=13&call_to_action%5Btype%5D=LEARN_MORE&call_to_action%5Bvalue%5D%5Blink%5D=http%3A%2F%2Fexample.com&call_to_action%5Bvalue%5D%5Bsponsorship%5D%5Bimage%5D=http%3A%2F%2Fexample.com%2Fbar.jpg', $body);
+    }
 }


### PR DESCRIPTION
Inspired by #383, I went in to add tests to 4.1 to show it had multidimensional-arrays-to-nested-params support and it did for `application/x-www-form-urlencoded` requests, but not `multipart/form-data` requests.

This is an important feature since you might want to target an audience for a video on a page post for example:

```php
$fb = new Facebook\Facebook([/* . . . */]);

$data = [
  'title' => 'Foo Video',
  'description' => 'My foo video.',
  'source' => $fb->videoToUpload('/path/to/video.mp4'),
  'targeting' => [
  	'countries' => 'US,GB',
  	'age_min' => 13,
  ],
];

$response = $fb->post('/{some-page-id}/videos', $data, '{page-access-token}');
```

Before this PR, PHP would poop out an error:

    Notice: Array to string conversion in /path/to/facebook-php-sdk-v4/src/Facebook/Http/RequestBodyMultipart.php on line 134

This PR fixes this issue by adding nested param support to `multipart/form-data` requests.