### PR TITLE
[4.0][Fix] Fix stdClass error on FacebookRedirectLoginHelper

### DIFF
--- a/src/Facebook/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/FacebookRedirectLoginHelper.php
@@ -188,8 +188,17 @@ class FacebookRedirectLoginHelper
         '/oauth/access_token',
         $params
       ))->execute()->getResponse();
-      if (isset($response['access_token'])) {
-        return new FacebookSession($response['access_token']);
+
+      // Graph v2.3 and greater return objects on the /oauth/access_token endpoint
+      $accessToken = null;
+      if (is_object($response) && isset($response->access_token)) {
+        $accessToken = $response->access_token;
+      } elseif (is_array($response) && isset($response['access_token'])) {
+        $accessToken = $response['access_token'];
+      }
+
+      if (isset($accessToken)) {
+        return new FacebookSession($accessToken);
       }
     }
     return null;


### PR DESCRIPTION
In Graph `v2.2` and below, GET requests to the `/oauth/access_token` endpoint would return a query string in the body of the response:

```
access_token=foo_token&expires=5183759
```

Starting in Graph `v2.3`, the response body is json:

```
{"access_token":"foo_token","token_type":"bearer","expires_in":5183686}
```

Since v4.0 of the PHP SDK translated these two responses differently, it was causing errors for anyone using Graph v2.3 (#391, #392 and even [here](https://github.com/SammyK/LaravelFacebookSdk/issues/56)). This PR is an ugly hack to fix this without BC's. :)

Not sure if this response change will affect any other places in 4.0, but if we get any more issues about `stdClass` errors, you can bet it's due to the Graph response change.

Version 4.1 of the SDK is unaffected.