### PR TITLE
Add scrutinizer config for PSR-2 checks

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,8 @@
+filter:
+    paths:
+        - 'src/*'
+
+tools:
+    php_code_sniffer:
+        config:
+            standard: PSR2


### PR DESCRIPTION
Just realized that we don't have scrutinizer configured to check for PSR-2 which is why #405 is passing even though it's got PSR-2 violations in it. I *think* this PR will force PSR-2 checks on scrutinizer's end. :)