### PR TITLE
Remove branch alias on 4.1-dev branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,5 @@
         "psr-4": {
             "Facebook\\Tests\\": "tests/"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.1.x-dev"
-        }
     }
 }


### PR DESCRIPTION
This is a tandem PR with the one I'm about to submit on `master`.

@yguedidi Can you review this one and the one I'm about to submit to ensure this is going to not break the existing aliases and also enable `~5.0@dev`?