### PR TITLE
Add branch alias for PHP SDK v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.1.x-dev"
+            "dev-master": "5.x-dev"
         }
     }
 }


### PR DESCRIPTION
This should add an alias for `~5.0@dev` on the master branch.

@yguedidi Can you ensure this + #417 will do what we've been discussing? :)