### PR TITLE
Further prep for v5

### DIFF
--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -199,6 +199,7 @@ class Facebook
         if (isset($config['default_graph_version'])) {
             $this->defaultGraphVersion = $config['default_graph_version'];
         } else {
+            // @todo v6: Throw an InvalidArgumentException if "default_graph_version" is not set
             $this->defaultGraphVersion = static::DEFAULT_GRAPH_VERSION;
         }
     }

--- a/src/Facebook/autoload.php
+++ b/src/Facebook/autoload.php
@@ -46,8 +46,16 @@ spl_autoload_register(function ($class) {
     // project-specific namespace prefix
     $prefix = 'Facebook\\';
 
+    // For backwards compatibility
+    $customBaseDir = '';
+    // @todo v6: Remove support for 'FACEBOOK_SDK_V4_SRC_DIR'
+    if (defined('FACEBOOK_SDK_V4_SRC_DIR')) {
+        $customBaseDir = FACEBOOK_SDK_V4_SRC_DIR;
+    } elseif (defined('FACEBOOK_SDK_SRC_DIR')) {
+        $customBaseDir = FACEBOOK_SDK_SRC_DIR;
+    }
     // base directory for the namespace prefix
-    $base_dir = defined('FACEBOOK_SDK_V4_SRC_DIR') ? FACEBOOK_SDK_V4_SRC_DIR : __DIR__ . '/';
+    $baseDir = $customBaseDir ?: __DIR__ . '/';
 
     // does the class use the namespace prefix?
     $len = strlen($prefix);
@@ -57,12 +65,12 @@ spl_autoload_register(function ($class) {
     }
 
     // get the relative class name
-    $relative_class = substr($class, $len);
+    $relativeClass = substr($class, $len);
 
     // replace the namespace prefix with the base directory, replace namespace
     // separators with directory separators in the relative class name, append
     // with .php
-    $file = rtrim($base_dir, '/') . '/' . str_replace('\\', '/', $relative_class) . '.php';
+    $file = rtrim($baseDir, '/') . '/' . str_replace('\\', '/', $relativeClass) . '.php';
 
     // if the file exists, require it
     if (file_exists($file)) {


### PR DESCRIPTION
- Deprecated `FACEBOOK_SDK_V4_SRC_DIR` for unversioned `FACEBOOK_SDK_SRC_DIR`
- Added a TODO note to force the `default_graph_version` option in v6