### PR TITLE
Update README badges for specific branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Facebook SDK for PHP
 
-[![Build Status](https://img.shields.io/travis/facebook/facebook-php-sdk-v4/master.svg)](https://travis-ci.org/facebook/facebook-php-sdk-v4)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/?branch=master)
+[![Build Status](https://img.shields.io/travis/facebook/facebook-php-sdk-v4/4.1-dev.svg)](https://travis-ci.org/facebook/facebook-php-sdk-v4)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/badges/quality-score.png?b=4.1-dev)](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/?branch=4.1-dev)
 [![Development Version](https://img.shields.io/badge/Development%20Version-4.1.0-orange.svg)](https://packagist.org/packages/facebook/php-sdk-v4)
 
 
@@ -15,7 +15,7 @@ The Facebook PHP SDK can be installed with [Composer](https://getcomposer.org/).
 ```json
 {
     "require": {
-        "facebook/php-sdk-v4": "~4.1.0"
+        "facebook/php-sdk-v4": "~4.1.0@dev"
     }
 }
 ```


### PR DESCRIPTION
Since the `4.1-dev` branch is not going to reflect `master` anymore, we can update the badges. The Scrutinizer one doesn't work for some reason.