### PR TITLE
Fix `getExpiresAt` Typo.

### DIFF
--- a/docs/GraphObject.fbmd
+++ b/docs/GraphObject.fbmd
@@ -40,7 +40,7 @@ echo $loc->getCountry();
 
 // SessionInfo example
 $info = $session->getSessionInfo());
-echo $info->getxpiresAt();
+echo $info->getExpiresAt();
 ~~~~
 
 </card>


### PR DESCRIPTION
Was reading the docs and found this typo. Thought I'd send a PR.

