### PR TITLE
Fixes #438

### DIFF
--- a/src/Facebook/FacebookBatchRequest.php
+++ b/src/Facebook/FacebookBatchRequest.php
@@ -252,7 +252,11 @@ class FacebookBatchRequest extends FacebookRequest implements IteratorAggregate,
             $batch['attached_files'] = $attachedFiles;
         }
 
-        // @TODO Add support for "omit_response_on_success"
+        $requestparams = $request->getParams();
+        if (array_key_exists('omit_response_on_success', $requestparams)){
+          $batch['omit_response_on_success'] = $requestparams['omit_response_on_success'];
+        }
+
         // @TODO Add support for "depends_on"
         // @TODO Add support for JSONP with "callback"
 


### PR DESCRIPTION
I have not written a test for this nor have I added it to the docs

If I am not mistaken, this will submit omit_response_on_success as part of both the query string and as a field in the form data. since it is ignored as a query string parameter by the restful api the solution works.

An ideal solution might remove the parameter from the request object prior to the getBody() request