### PR TITLE
Fix: No need for else branch as we're returning early

### DIFF
--- a/src/Facebook/FacebookResponse.php
+++ b/src/Facebook/FacebookResponse.php
@@ -198,9 +198,9 @@ class FacebookResponse
         $this->request->getPath(),
         $params
       );
-    } else {
-      return null;
     }
+
+    return null;
   }
 
 }


### PR DESCRIPTION
This PR

* [x] removes an `else` branch as we're returning early in the `if` branch already