### PR TITLE
Fix: Method accepts only two arguments, not four

### DIFF
--- a/src/Facebook/GraphNodes/GraphNodeFactory.php
+++ b/src/Facebook/GraphNodes/GraphNodeFactory.php
@@ -331,7 +331,7 @@ class GraphNodeFactory
 
         $dataList = [];
         foreach ($data['data'] as $graphNode) {
-            $dataList[] = $this->safelyMakeGraphNode($graphNode, $subclassName, $parentKey, $parentNodeId);
+            $dataList[] = $this->safelyMakeGraphNode($graphNode, $subclassName);
         }
 
         $metaData = $this->getMetaData($data);


### PR DESCRIPTION
This PR

* [x] removes arguments from a method call as the signature only accepts two anyway

Follows https://github.com/facebook/facebook-php-sdk-v4/pull/468#issuecomment-124215827.