### PR TITLE
Add an option to set the app access token as default

### DIFF
--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -283,6 +283,12 @@ class Facebook
      */
     public function setDefaultAccessToken($accessToken)
     {
+        if ($accessToken === 'app_token') {
+            $this->defaultAccessToken = $this->app->getAccessToken();
+
+            return;
+        }
+
         if (is_string($accessToken)) {
             $this->defaultAccessToken = new AccessToken($accessToken);
 


### PR DESCRIPTION
Then you can do this:
```php
$fb = new Facebook\Facebook([
    'default_access_token' => 'app_token'
]);

// or

$fb->setDefaultAccessToken('app_token');
```