### PR TITLE
Fix: Deep Pagination does not append extra parameters anymore

### DIFF
--- a/src/Facebook/GraphNodes/GraphEdge.php
+++ b/src/Facebook/GraphNodes/GraphEdge.php
@@ -153,35 +153,13 @@ class GraphEdge extends Collection
         $this->validateForPagination();
 
         // Do we have a paging URL?
-        if (isset($this->metaData['paging'][$direction])) {
-            // Graph returns the full URL with all the original params.
-            // We just want the endpoint though.
-            $pageUrl = $this->metaData['paging'][$direction];
-
-            return FacebookUrlManipulator::baseGraphUrlEndpoint($pageUrl);
-        }
-
-        // Do we have a cursor to work with?
-        $cursorDirection = $direction === 'next' ? 'after' : 'before';
-        $cursor = $this->getCursor($cursorDirection);
-        if (!$cursor) {
+        if (!isset($this->metaData['paging'][$direction])) {
             return null;
         }
 
-        // If we don't know the ID of the parent node, this ain't gonna work.
-        if (!$this->parentEdgeEndpoint) {
-            return null;
-        }
+        $pageUrl = $this->metaData['paging'][$direction];
 
-        // We have the parent node ID, paging cursor & original request.
-        // These were the ingredients chosen to create the perfect little URL.
-        $pageUrl = $this->parentEdgeEndpoint . '?' . $cursorDirection . '=' . urlencode($cursor);
-
-        // Pull in the original params
-        $originalUrl = $this->request->getUrl();
-        $pageUrl = FacebookUrlManipulator::mergeUrlParams($originalUrl, $pageUrl);
-
-        return FacebookUrlManipulator::forceSlashPrefix($pageUrl);
+        return FacebookUrlManipulator::baseGraphUrlEndpoint($pageUrl);
     }
 
     /**

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -363,6 +363,8 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
                         'after' => 'bar_after_cursor',
                         'before' => 'bar_before_cursor',
                     ],
+                    'previous' => 'previous_url',
+                    'next' => 'next_url',
                 ]
             ],
             '/1337/photos',

--- a/tests/GraphNodes/GraphEdgeTest.php
+++ b/tests/GraphNodes/GraphEdgeTest.php
@@ -35,15 +35,9 @@ class GraphEdgeTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-    protected $basePagination = [
+    protected $pagination = [
         'next' => 'https://graph.facebook.com/v7.12/998899/photos?pretty=0&limit=25&after=foo_after_cursor',
         'previous' => 'https://graph.facebook.com/v7.12/998899/photos?pretty=0&limit=25&before=foo_before_cursor',
-    ];
-    protected $cursorPagination = [
-        'cursors' => [
-            'after' => 'bar_after_cursor',
-            'before' => 'bar_before_cursor',
-        ],
     ];
 
     public function setUp()
@@ -75,7 +69,7 @@ class GraphEdgeTest extends \PHPUnit_Framework_TestCase
         $graphEdge = new GraphEdge(
             $this->request,
             [],
-            ['paging' => $this->basePagination]
+            ['paging' => $this->pagination]
         );
         $nextPage = $graphEdge->getPaginationUrl('next');
         $prevPage = $graphEdge->getPaginationUrl('previous');
@@ -84,27 +78,12 @@ class GraphEdgeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/998899/photos?pretty=0&limit=25&before=foo_before_cursor', $prevPage);
     }
 
-    public function testCanGeneratePaginationEndpointsFromACursor()
-    {
-        $graphEdge = new GraphEdge(
-            $this->request,
-            [],
-            ['paging' => $this->cursorPagination],
-            '/1234567890/likes'
-        );
-        $nextPage = $graphEdge->getPaginationUrl('next');
-        $prevPage = $graphEdge->getPaginationUrl('previous');
-
-        $this->assertEquals('/1234567890/likes?access_token=foo_token&after=bar_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&keep=me', $nextPage);
-        $this->assertEquals('/1234567890/likes?access_token=foo_token&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&before=bar_before_cursor&foo=bar&keep=me', $prevPage);
-    }
-
     public function testCanInstantiateNewPaginationRequest()
     {
         $graphEdge = new GraphEdge(
             $this->request,
             [],
-            ['paging' => $this->cursorPagination],
+            ['paging' => $this->pagination],
             '/1234567890/likes'
         );
         $nextPage = $graphEdge->getNextPageRequest();
@@ -114,7 +93,7 @@ class GraphEdgeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Facebook\FacebookRequest', $prevPage);
         $this->assertNotSame($this->request, $nextPage);
         $this->assertNotSame($this->request, $prevPage);
-        $this->assertEquals('/v1337/1234567890/likes?access_token=foo_token&after=bar_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&keep=me', $nextPage->getUrl());
-        $this->assertEquals('/v1337/1234567890/likes?access_token=foo_token&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&before=bar_before_cursor&foo=bar&keep=me', $prevPage->getUrl());
+        $this->assertEquals('/v1337/998899/photos?access_token=foo_token&after=foo_after_cursor&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&foo=bar&limit=25&pretty=0', $nextPage->getUrl());
+        $this->assertEquals('/v1337/998899/photos?access_token=foo_token&appsecret_proof=857d5f035a894f16b4180f19966e055cdeab92d4d53017b13dccd6d43b6497af&before=foo_before_cursor&foo=bar&limit=25&pretty=0', $prevPage->getUrl());
     }
 }


### PR DESCRIPTION
Related with https://github.com/facebook/facebook-php-sdk-v4/issues/483