### PR TITLE
Add custom PHP_CodeSniffer rule set to ignore long line lengths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ $ composer global require squizlabs/php_codesniffer
 Then you can `cd` into the Facebook PHP SDK folder and run Code Sniffer against the `src/` directory.
 
 ``` bash
-$ ~/.composer/vendor/bin/phpcs src --standard=psr2 -sp
+$ ~/.composer/vendor/bin/phpcs src --standard=psr2 -spn
 ```
 
 **Happy coding**!


### PR DESCRIPTION
# 500th PR!!!!!!

![](https://media.giphy.com/media/qHyNwshIEVysU/giphy.gif)

-------

The current output of the code sniffer outputs this:

```
FILE: ...k-php-sdk-v4/src/Facebook/Authentication/AccessTokenMetadata.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 360 | WARNING | Line exceeds 120 characters; contains 128
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...facebook-php-sdk-v4/src/Facebook/Authentication/OAuth2Client.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 146 | WARNING | Line exceeds 120 characters; contains 139
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...ammyK/Sites/_forks/facebook-php-sdk-v4/src/Facebook/Facebook.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 9 WARNINGS AFFECTING 9 LINES
----------------------------------------------------------------------
 133 | WARNING | Line exceeds 120 characters; contains 174
     |         | characters (Generic.Files.LineLength.TooLong)
 138 | WARNING | Line exceeds 120 characters; contains 182
     |         | characters (Generic.Files.LineLength.TooLong)
 154 | WARNING | Line exceeds 120 characters; contains 192
     |         | characters (Generic.Files.LineLength.TooLong)
 165 | WARNING | Line exceeds 120 characters; contains 139
     |         | characters (Generic.Files.LineLength.TooLong)
 179 | WARNING | Line exceeds 120 characters; contains 226
     |         | characters (Generic.Files.LineLength.TooLong)
 191 | WARNING | Line exceeds 120 characters; contains 188
     |         | characters (Generic.Files.LineLength.TooLong)
 298 | WARNING | Line exceeds 120 characters; contains 121
     |         | characters (Generic.Files.LineLength.TooLong)
 498 | WARNING | Line exceeds 120 characters; contains 128
     |         | characters (Generic.Files.LineLength.TooLong)
 546 | WARNING | Line exceeds 120 characters; contains 124
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ..._forks/facebook-php-sdk-v4/src/Facebook/FacebookBatchRequest.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------
  57 | WARNING | Line exceeds 120 characters; contains 121
     |         | characters (Generic.Files.LineLength.TooLong)
 116 | WARNING | Line exceeds 120 characters; contains 139
     |         | characters (Generic.Files.LineLength.TooLong)
 124 | WARNING | Line exceeds 120 characters; contains 140
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...ites/_forks/facebook-php-sdk-v4/src/Facebook/FacebookRequest.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------
  97 | WARNING | Line exceeds 120 characters; contains 167
     |         | characters (Generic.Files.LineLength.TooLong)
 140 | WARNING | Line exceeds 120 characters; contains 179
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...rks/facebook-php-sdk-v4/src/Facebook/FileUpload/FacebookFile.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 2 WARNINGS AFFECTING 2 LINES
----------------------------------------------------------------------
 74 | WARNING | Line exceeds 120 characters; contains 130
    |         | characters (Generic.Files.LineLength.TooLong)
 80 | WARNING | Line exceeds 120 characters; contains 130
    |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ..._forks/facebook-php-sdk-v4/src/Facebook/GraphNodes/GraphEdge.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 66 | WARNING | Line exceeds 120 characters; contains 147
    |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...forks/facebook-php-sdk-v4/src/Facebook/GraphNodes/GraphGroup.php
----------------------------------------------------------------------
FOUND 1 ERROR AND 2 WARNINGS AFFECTING 3 LINES
----------------------------------------------------------------------
  72 | WARNING | [ ] Line exceeds 120 characters; contains 147
     |         |     characters
     |         |     (Generic.Files.LineLength.TooLong)
 152 | WARNING | [ ] Line exceeds 120 characters; contains 201
     |         |     characters
     |         |     (Generic.Files.LineLength.TooLong)
 171 | ERROR   | [x] The closing brace for the class must go on
     |         |     the next line after the body
     |         |     (PSR2.Classes.ClassDeclaration.CloseBraceAfterBody)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: ...facebook-php-sdk-v4/src/Facebook/GraphNodes/GraphNodeFactory.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 6 WARNINGS AFFECTING 6 LINES
----------------------------------------------------------------------
 225 | WARNING | Line exceeds 120 characters; contains 169
     |         | characters (Generic.Files.LineLength.TooLong)
 240 | WARNING | Line exceeds 120 characters; contains 177
     |         | characters (Generic.Files.LineLength.TooLong)
 299 | WARNING | Line exceeds 120 characters; contains 122
     |         | characters (Generic.Files.LineLength.TooLong)
 343 | WARNING | Line exceeds 120 characters; contains 124
     |         | characters (Generic.Files.LineLength.TooLong)
 386 | WARNING | Line exceeds 120 characters; contains 125
     |         | characters (Generic.Files.LineLength.TooLong)
 390 | WARNING | Line exceeds 120 characters; contains 163
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...-php-sdk-v4/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 6 WARNINGS AFFECTING 6 LINES
----------------------------------------------------------------------
  75 | WARNING | Line exceeds 120 characters; contains 139
     |         | characters (Generic.Files.LineLength.TooLong)
  77 | WARNING | Line exceeds 120 characters; contains 207
     |         | characters (Generic.Files.LineLength.TooLong)
 142 | WARNING | Line exceeds 120 characters; contains 132
     |         | characters (Generic.Files.LineLength.TooLong)
 269 | WARNING | Line exceeds 120 characters; contains 124
     |         | characters (Generic.Files.LineLength.TooLong)
 276 | WARNING | Line exceeds 120 characters; contains 149
     |         | characters (Generic.Files.LineLength.TooLong)
 285 | WARNING | Line exceeds 120 characters; contains 149
     |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...acebook/PseudoRandomString/McryptPseudoRandomStringGenerator.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 35 | WARNING | Line exceeds 120 characters; contains 121
    |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------


FILE: ...cebook/PseudoRandomString/OpenSslPseudoRandomStringGenerator.php
----------------------------------------------------------------------
FOUND 0 ERRORS AND 4 WARNINGS AFFECTING 4 LINES
----------------------------------------------------------------------
 35 | WARNING | Line exceeds 120 characters; contains 131
    |         | characters (Generic.Files.LineLength.TooLong)
 43 | WARNING | Line exceeds 120 characters; contains 129
    |         | characters (Generic.Files.LineLength.TooLong)
 58 | WARNING | Line exceeds 120 characters; contains 127
    |         | characters (Generic.Files.LineLength.TooLong)
 62 | WARNING | Line exceeds 120 characters; contains 192
    |         | characters (Generic.Files.LineLength.TooLong)
----------------------------------------------------------------------

Time: 1.05 secs; Memory: 15.75Mb
```

The warnings are all for the decision to use long lines (blast you @yguedidi! :)). Believe it or not there is an actual error in that output, but it's hard to tell with all the warnings. This PR will tell CodeSniffer to ignore the long lines and the errors become more apparent:

```
FILE: ...forks/facebook-php-sdk-v4/src/Facebook/GraphNodes/GraphGroup.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 171 | ERROR | [x] The closing brace for the class must go on the
     |       |     next line after the body
     |       |     (PSR2.Classes.ClassDeclaration.CloseBraceAfterBody)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------

Time: 909ms; Memory: 15.25Mb
```

BTW, I fixed the aforementioned error in #499. :)