### PR TITLE
Complexity reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Version 5 of the Facebook PHP SDK is a complete refactor of version 4. It comes 
     - Renamed `FacebookHttpable` to `FacebookHttpClientInterface`
     - Added `FacebookApp` entity that contains info about the Facebook app
     - Updated the API for the helpers
+    - Added `HttpClients`, `PersistentData` and `PseudoRandomString` factories to reduce main class' complexity
   - Tests
     - Added namespaces to the tests
     - Grouped functional tests under `functional` group

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -158,14 +158,6 @@ class Facebook
         $enableBeta = isset($config['enable_beta_mode']) && $config['enable_beta_mode'] === true;
         $this->client = new FacebookClient($httpClientHandler, $enableBeta);
 
-        if (isset($config['url_detection_handler'])) {
-            if ($config['url_detection_handler'] instanceof UrlDetectionInterface) {
-                $this->urlDetectionHandler = $config['url_detection_handler'];
-            } else {
-                throw new \InvalidArgumentException('The url_detection_handler must be an instance of Facebook\Url\UrlDetectionInterface');
-            }
-        }
-
         if (isset($config['pseudo_random_string_generator'])) {
             if ($config['pseudo_random_string_generator'] instanceof PseudoRandomStringGeneratorInterface) {
                 $this->pseudoRandomStringGenerator = $config['pseudo_random_string_generator'];
@@ -191,6 +183,7 @@ class Facebook
                 throw new \InvalidArgumentException('The persistent_data_handler must be set to "session", "memory", or be an instance of Facebook\PersistentData\PersistentDataInterface');
             }
         }
+        $this->setUrlDetectionHandler($config['url_detection_handler'] ?: new FacebookUrlDetectionHandler());
 
         if (isset($config['default_access_token'])) {
             $this->setDefaultAccessToken($config['default_access_token']);
@@ -257,11 +250,17 @@ class Facebook
      */
     public function getUrlDetectionHandler()
     {
-        if (!$this->urlDetectionHandler instanceof UrlDetectionInterface) {
-            $this->urlDetectionHandler = new FacebookUrlDetectionHandler();
-        }
-
         return $this->urlDetectionHandler;
+    }
+
+    /**
+     * Changes the URL detection handler.
+     * 
+     * @param UrlDetectionInterface $urlDetectionHandler
+     */
+    private function setUrlDetectionHandler(UrlDetectionInterface $urlDetectionHandler)
+    {
+        $this->urlDetectionHandler = $urlDetectionHandler;
     }
 
     /**

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -30,17 +30,11 @@ use Facebook\FileUpload\FacebookVideo;
 use Facebook\GraphNodes\GraphEdge;
 use Facebook\Url\UrlDetectionInterface;
 use Facebook\Url\FacebookUrlDetectionHandler;
+use Facebook\PseudoRandomString\PseudoRandomStringGeneratorFactory;
 use Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface;
-use Facebook\PseudoRandomString\McryptPseudoRandomStringGenerator;
-use Facebook\PseudoRandomString\OpenSslPseudoRandomStringGenerator;
-use Facebook\PseudoRandomString\UrandomPseudoRandomStringGenerator;
-use Facebook\HttpClients\FacebookHttpClientInterface;
-use Facebook\HttpClients\FacebookCurlHttpClient;
-use Facebook\HttpClients\FacebookStreamHttpClient;
-use Facebook\HttpClients\FacebookGuzzleHttpClient;
+use Facebook\HttpClients\HttpClientsFactory;
+use Facebook\PersistentData\PersistentDataFactory;
 use Facebook\PersistentData\PersistentDataInterface;
-use Facebook\PersistentData\FacebookSessionPersistentDataHandler;
-use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
 use Facebook\Helpers\FacebookCanvasHelper;
 use Facebook\Helpers\FacebookJavaScriptHelper;
 use Facebook\Helpers\FacebookPageTabHelper;
@@ -128,73 +122,43 @@ class Facebook
      */
     public function __construct(array $config = [])
     {
-        $appId = isset($config['app_id']) ? $config['app_id'] : getenv(static::APP_ID_ENV_NAME);
-        if (!$appId) {
+        $config = array_merge([
+            'app_id' => getenv(static::APP_ID_ENV_NAME),
+            'app_secret' => getenv(static::APP_SECRET_ENV_NAME),
+            'default_graph_version' => static::DEFAULT_GRAPH_VERSION,
+            'enable_beta_mode' => false,
+            'http_client_handler' => null,
+            'persistent_data_handler' => null,
+            'pseudo_random_string_generator' => null,
+            'url_detection_handler' => null,
+        ], $config);
+
+        if (!$config['app_id']) {
             throw new FacebookSDKException('Required "app_id" key not supplied in config and could not find fallback environment variable "' . static::APP_ID_ENV_NAME . '"');
         }
-
-        $appSecret = isset($config['app_secret']) ? $config['app_secret'] : getenv(static::APP_SECRET_ENV_NAME);
-        if (!$appSecret) {
+        if (!$config['app_secret']) {
             throw new FacebookSDKException('Required "app_secret" key not supplied in config and could not find fallback environment variable "' . static::APP_SECRET_ENV_NAME . '"');
         }
 
-        $this->app = new FacebookApp($appId, $appSecret);
-
-        $httpClientHandler = null;
-        if (isset($config['http_client_handler'])) {
-            if ($config['http_client_handler'] instanceof FacebookHttpClientInterface) {
-                $httpClientHandler = $config['http_client_handler'];
-            } elseif ($config['http_client_handler'] === 'curl') {
-                $httpClientHandler = new FacebookCurlHttpClient();
-            } elseif ($config['http_client_handler'] === 'stream') {
-                $httpClientHandler = new FacebookStreamHttpClient();
-            } elseif ($config['http_client_handler'] === 'guzzle') {
-                $httpClientHandler = new FacebookGuzzleHttpClient();
-            } else {
-                throw new \InvalidArgumentException('The http_client_handler must be set to "curl", "stream", "guzzle", or be an instance of Facebook\HttpClients\FacebookHttpClientInterface');
-            }
-        }
-
-        $enableBeta = isset($config['enable_beta_mode']) && $config['enable_beta_mode'] === true;
-        $this->client = new FacebookClient($httpClientHandler, $enableBeta);
-
-        if (isset($config['pseudo_random_string_generator'])) {
-            if ($config['pseudo_random_string_generator'] instanceof PseudoRandomStringGeneratorInterface) {
-                $this->pseudoRandomStringGenerator = $config['pseudo_random_string_generator'];
-            } elseif ($config['pseudo_random_string_generator'] === 'mcrypt') {
-                $this->pseudoRandomStringGenerator = new McryptPseudoRandomStringGenerator();
-            } elseif ($config['pseudo_random_string_generator'] === 'openssl') {
-                $this->pseudoRandomStringGenerator = new OpenSslPseudoRandomStringGenerator();
-            } elseif ($config['pseudo_random_string_generator'] === 'urandom') {
-                $this->pseudoRandomStringGenerator = new UrandomPseudoRandomStringGenerator();
-            } else {
-                throw new \InvalidArgumentException('The pseudo_random_string_generator must be set to "mcrypt", "openssl", or "urandom", or be an instance of Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface');
-            }
-        }
-
-        if (isset($config['persistent_data_handler'])) {
-            if ($config['persistent_data_handler'] instanceof PersistentDataInterface) {
-                $this->persistentDataHandler = $config['persistent_data_handler'];
-            } elseif ($config['persistent_data_handler'] === 'session') {
-                $this->persistentDataHandler = new FacebookSessionPersistentDataHandler();
-            } elseif ($config['persistent_data_handler'] === 'memory') {
-                $this->persistentDataHandler = new FacebookMemoryPersistentDataHandler();
-            } else {
-                throw new \InvalidArgumentException('The persistent_data_handler must be set to "session", "memory", or be an instance of Facebook\PersistentData\PersistentDataInterface');
-            }
-        }
+        $this->app = new FacebookApp($config['app_id'], $config['app_secret']);
+        $this->client = new FacebookClient(
+            HttpClientsFactory::createHttpClient($config['http_client_handler']),
+            $config['enable_beta_mode']
+        );
+        $this->pseudoRandomStringGenerator = PseudoRandomStringGeneratorFactory::createPseudoRandomStringGenerator(
+            $config['pseudo_random_string_generator']
+        );
         $this->setUrlDetectionHandler($config['url_detection_handler'] ?: new FacebookUrlDetectionHandler());
+        $this->persistentDataHandler = PersistentDataFactory::createPersistentDataHandler(
+            $config['persistent_data_handler']
+        );
 
         if (isset($config['default_access_token'])) {
             $this->setDefaultAccessToken($config['default_access_token']);
         }
 
-        if (isset($config['default_graph_version'])) {
-            $this->defaultGraphVersion = $config['default_graph_version'];
-        } else {
-            // @todo v6: Throw an InvalidArgumentException if "default_graph_version" is not set
-            $this->defaultGraphVersion = static::DEFAULT_GRAPH_VERSION;
-        }
+        // @todo v6: Throw an InvalidArgumentException if "default_graph_version" is not set
+        $this->defaultGraphVersion = $config['default_graph_version'];
     }
 
     /**
@@ -255,7 +219,7 @@ class Facebook
 
     /**
      * Changes the URL detection handler.
-     * 
+     *
      * @param UrlDetectionInterface $urlDetectionHandler
      */
     private function setUrlDetectionHandler(UrlDetectionInterface $urlDetectionHandler)

--- a/src/Facebook/HttpClients/HttpClientsFactory.php
+++ b/src/Facebook/HttpClients/HttpClientsFactory.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\HttpClients;
+
+use GuzzleHttp\Client;
+use InvalidArgumentException;
+
+class HttpClientsFactory
+{
+    private function __construct()
+    {
+        // a factory constructor should never be invoked
+    }
+
+    /**
+     * HTTP client generation.
+     *
+     * @param FacebookHttpClientInterface|Client|string|null $handler
+     *
+     * @throws Exception                If the cURL extension or the Guzzle client aren't available (if required).
+     * @throws InvalidArgumentException If the http client handler isn't "curl", "stream", "guzzle", or an instance of Facebook\HttpClients\FacebookHttpClientInterface.
+     *
+     * @return FacebookHttpClientInterface
+     */
+    public static function createHttpClient($handler)
+    {
+        if (!$handler) {
+            return self::detectDefaultClient();
+        }
+
+        if ($handler instanceof FacebookHttpClientInterface) {
+            return $handler;
+        }
+
+        if ('stream' === $handler) {
+            return new FacebookStreamHttpClient();
+        }
+        if ('curl' === $handler) {
+            if (!extension_loaded('curl')) {
+                throw new Exception('The cURL extension must be loaded in order to use the "curl" handler.');
+            }
+
+            return new FacebookCurlHttpClient();
+        }
+
+        if ('guzzle' === $handler && !class_exists('GuzzleHttp\Client')) {
+            throw new Exception('The Guzzle HTTP client must be included in order to use the "guzzle" handler.');
+        }
+
+        if ($handler instanceof Client) {
+            return new FacebookGuzzleHttpClient($handler);
+        }
+        if ('guzzle' === $handler) {
+            return new FacebookGuzzleHttpClient();
+        }
+
+        throw new InvalidArgumentException('The http client handler must be set to "curl", "stream", "guzzle", be an instance of GuzzleHttp\Client or an instance of Facebook\HttpClients\FacebookHttpClientInterface');
+    }
+
+    /**
+     * Detect default HTTP client.
+     *
+     * @return FacebookHttpClientInterface
+     */
+    private static function detectDefaultClient()
+    {
+        if (extension_loaded('curl')) {
+            return new FacebookCurlHttpClient();
+        }
+
+        if (class_exists('GuzzleHttp\Client')) {
+            return new FacebookGuzzleHttpClient();
+        }
+
+        return new FacebookStreamHttpClient();
+    }
+}

--- a/src/Facebook/PersistentData/PersistentDataFactory.php
+++ b/src/Facebook/PersistentData/PersistentDataFactory.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PersistentData;
+
+use InvalidArgumentException;
+
+class PersistentDataFactory
+{
+    private function __construct()
+    {
+        // a factory constructor should never be invoked
+    }
+
+    /**
+     * PersistentData generation.
+     *
+     * @param PersistentDataInterface|string|null $handler
+     *
+     * @throws InvalidArgumentException If the persistent data handler isn't "session", "memory", or an instance of Facebook\PersistentData\PersistentDataInterface.
+     *
+     * @return PersistentDataInterface
+     */
+    public static function createPersistentDataHandler($handler)
+    {
+        if (!$handler) {
+            return session_status() === PHP_SESSION_ACTIVE
+                ? new FacebookSessionPersistentDataHandler()
+                : new FacebookMemoryPersistentDataHandler();
+        }
+
+        if ($handler instanceof PersistentDataInterface) {
+            return $handler;
+        }
+
+        if ('session' === $handler) {
+            new FacebookSessionPersistentDataHandler();
+        }
+        if ('memory' === $handler) {
+            return new FacebookMemoryPersistentDataHandler();
+        }
+
+        throw new InvalidArgumentException('The persistent data handler must be set to "session", "memory", or be an instance of Facebook\PersistentData\PersistentDataInterface');
+    }
+}

--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorFactory.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorFactory.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\PseudoRandomString;
+
+use Facebook\Exceptions\FacebookSDKException;
+use InvalidArgumentException;
+
+class PseudoRandomStringGeneratorFactory
+{
+    private function __construct()
+    {
+        // a factory constructor should never be invoked
+    }
+
+    /**
+     * Pseudo random string generator creation.
+     *
+     * @param PseudoRandomStringGeneratorInterface|string|null $generator
+     *
+     * @throws InvalidArgumentException If the pseudo random string generator must be set to "mcrypt", "openssl", or "urandom", or be an instance of Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface.
+     *
+     * @return PseudoRandomStringGeneratorInterface
+     */
+    public static function createPseudoRandomStringGenerator($generator)
+    {
+        if (!$generator) {
+            return self::detectDefaultPseudoRandomStringGenerator();
+        }
+
+        if ($generator instanceof PseudoRandomStringGeneratorInterface) {
+            return $generator;
+        }
+
+        if ('mcrypt' === $generator) {
+            return new McryptPseudoRandomStringGenerator();
+        }
+        if ('openssl' === $generator) {
+            return new OpenSslPseudoRandomStringGenerator();
+        }
+        if ('urandom' === $generator) {
+            return new UrandomPseudoRandomStringGenerator();
+        }
+
+        throw new InvalidArgumentException('The pseudo random string generator must be set to "mcrypt", "openssl", or "urandom", or be an instance of Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface');
+    }
+
+    /**
+     * Detects which pseudo-random string generator to use.
+     *
+     * @throws FacebookSDKException If unable to detect a cryptographically secure pseudo-random string generator.
+     *
+     * @return PseudoRandomStringGeneratorInterface
+     */
+    private static function detectDefaultPseudoRandomStringGenerator()
+    {
+        // Since openssl_random_pseudo_bytes() can sometimes return non-cryptographically
+        // secure pseudo-random strings (in rare cases), we check for mcrypt_create_iv() first.
+        if (function_exists('mcrypt_create_iv')) {
+            return new McryptPseudoRandomStringGenerator();
+        }
+
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            return new OpenSslPseudoRandomStringGenerator();
+        }
+
+        if (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
+            return new UrandomPseudoRandomStringGenerator();
+        }
+
+        throw new FacebookSDKException('Unable to detect a cryptographically secure pseudo-random string generator.');
+    }
+}

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -176,11 +176,14 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSettingAnInvalidUrlHandlerThrows()
     {
+        $expectedException = (PHP_MAJOR_VERSION > 5 && class_exists('TypeError'))
+            ? 'TypeError'
+            : 'PHPUnit_Framework_Error';
+
+        $this->setExpectedException($expectedException);
+
         $config = array_merge($this->config, [
             'url_detection_handler' => 'foo_handler',
         ]);

--- a/tests/HttpClients/HttpClientsFactoryTest.php
+++ b/tests/HttpClients/HttpClientsFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\HttpClients;
+
+use Facebook\HttpClients\FacebookCurlHttpClient;
+use Facebook\HttpClients\FacebookGuzzleHttpClient;
+use Facebook\HttpClients\FacebookStreamHttpClient;
+use Facebook\HttpClients\HttpClientsFactory;
+use GuzzleHttp\Client;
+use PHPUnit_Framework_TestCase;
+
+class HttpClientsFactoryTest extends PHPUnit_Framework_TestCase
+{
+    const COMMON_NAMESPACE = 'Facebook\HttpClients\\';
+    const COMMON_INTERFACE = 'Facebook\HttpClients\FacebookHttpClientInterface';
+
+    /**
+     * @param mixed  $handler
+     * @param string $expected
+     *
+     * @dataProvider httpClientsProvider
+     */
+    public function testCreateHttpClient($handler, $expected)
+    {
+        $httpClient = HttpClientsFactory::createHttpClient($handler);
+
+        $this->assertInstanceOf(self::COMMON_INTERFACE, $httpClient);
+        $this->assertInstanceOf($expected, $httpClient);
+    }
+
+    /**
+     * @return array
+     */
+    public function httpClientsProvider()
+    {
+        return [
+            ['curl', self::COMMON_NAMESPACE . 'FacebookCurlHttpClient'],
+            ['guzzle', self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
+            ['stream', self::COMMON_NAMESPACE . 'FacebookStreamHttpClient'],
+            [new Client(), self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
+            [new FacebookCurlHttpClient(), self::COMMON_NAMESPACE . 'FacebookCurlHttpClient'],
+            [new FacebookGuzzleHttpClient(), self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
+            [new FacebookStreamHttpClient(), self::COMMON_NAMESPACE . 'FacebookStreamHttpClient'],
+            [null, self::COMMON_INTERFACE],
+        ];
+    }
+}

--- a/tests/PersistentData/PersistentDataFactoryTest.php
+++ b/tests/PersistentData/PersistentDataFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PersistentData;
+
+use Facebook\PersistentData\FacebookMemoryPersistentDataHandler;
+use Facebook\PersistentData\FacebookSessionPersistentDataHandler;
+use Facebook\PersistentData\PersistentDataFactory;
+use PHPUnit_Framework_TestCase;
+
+class PersistentDataFactoryTest extends PHPUnit_Framework_TestCase
+{
+    const COMMON_NAMESPACE = 'Facebook\PersistentData\\';
+    const COMMON_INTERFACE = 'Facebook\PersistentData\PersistentDataInterface';
+
+    /**
+     * @param mixed  $handler
+     * @param string $expected
+     *
+     * @dataProvider persistentDataHandlerProviders
+     */
+    public function testCreatePersistentDataHandler($handler, $expected)
+    {
+        $persistentDataHandler = PersistentDataFactory::createPersistentDataHandler($handler);
+
+        $this->assertInstanceOf(self::COMMON_INTERFACE, $persistentDataHandler);
+        $this->assertInstanceOf($expected, $persistentDataHandler);
+    }
+
+    /**
+     * @return array
+     */
+    public function persistentDataHandlerProviders()
+    {
+        $handlers = [
+            ['memory', self::COMMON_NAMESPACE . 'FacebookMemoryPersistentDataHandler'],
+            [new FacebookMemoryPersistentDataHandler(), self::COMMON_NAMESPACE . 'FacebookMemoryPersistentDataHandler'],
+            [new FacebookSessionPersistentDataHandler(false), self::COMMON_NAMESPACE . 'FacebookSessionPersistentDataHandler'],
+            [null, self::COMMON_INTERFACE],
+        ];
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $handlers[] = ['session', self::COMMON_NAMESPACE . 'FacebookSessionPersistentDataHandler'];
+        }
+
+        return $handlers;
+    }
+}

--- a/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
+++ b/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ * use, copy, modify, and distribute this software in source code or binary
+ * form for use in connection with the web services and APIs provided by
+ * Facebook.
+ *
+ * As with any software that integrates with the Facebook platform, your use
+ * of this software is subject to the Facebook Developer Principles and
+ * Policies [http://developers.facebook.com/policy/]. This copyright notice
+ * shall be included in all copies or substantial portions of the software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+namespace Facebook\Tests\PseudoRandomString;
+
+use Facebook\PseudoRandomString\McryptPseudoRandomStringGenerator;
+use Facebook\PseudoRandomString\OpenSslPseudoRandomStringGenerator;
+use Facebook\PseudoRandomString\PseudoRandomStringGeneratorFactory;
+use Facebook\PseudoRandomString\UrandomPseudoRandomStringGenerator;
+use PHPUnit_Framework_TestCase;
+
+class PseudoRandomStringFactoryTest extends PHPUnit_Framework_TestCase
+{
+    const COMMON_NAMESPACE = 'Facebook\PseudoRandomString\\';
+    const COMMON_INTERFACE = 'Facebook\PseudoRandomString\PseudoRandomStringGeneratorInterface';
+
+    /**
+     * @param mixed  $handler
+     * @param string $expected
+     *
+     * @dataProvider httpClientsProvider
+     */
+    public function testCreateHttpClient($handler, $expected)
+    {
+        $pseudoRandomStringGenerator = PseudoRandomStringGeneratorFactory::createPseudoRandomStringGenerator($handler);
+
+        $this->assertInstanceOf(self::COMMON_INTERFACE, $pseudoRandomStringGenerator);
+        $this->assertInstanceOf($expected, $pseudoRandomStringGenerator);
+    }
+
+    /**
+     * @return array
+     */
+    public function httpClientsProvider()
+    {
+        return [
+            ['mcrypt', self::COMMON_NAMESPACE . 'McryptPseudoRandomStringGenerator'],
+            ['openssl', self::COMMON_NAMESPACE . 'OpenSslPseudoRandomStringGenerator'],
+            ['urandom', self::COMMON_NAMESPACE . 'UrandomPseudoRandomStringGenerator'],
+            [null, self::COMMON_INTERFACE],
+        ];
+    }
+}


### PR DESCRIPTION
To solve the `Facebook\Facebook` constructor complexity problem (defined on [Scrutinizer]()), I've splitted it into different factories:

* `Facebook\PseudoRandomString\PseudoRandomStringGeneratorFactory`
* `Facebook\HttpClients\HttpClientsFactory`
* `Facebook\PersistentData\PersistentDataFactory`

This should also allow you to move different detection logic into these factories and keeping some other classes' focus on their behaviour and responsabilities.

Another small change I did is the removal of an `\InvalidArgumentException` exception replicating a setter logic (afaik).

Of course I'll add related tests and documentation if the RFC is accepted.