### PR TITLE
Include link to upgrade guide in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The Facebook PHP SDK can be installed with [Composer](https://getcomposer.org/).
 }
 ```
 
+## Upgrading to v5.x
+
+Upgrading from v4.x? Facebook PHP SDK v5.x introduced breaking changes. Please [read the upgrade guide](https://www.sammyk.me/upgrading-the-facebook-php-sdk-from-v4-to-v5) before upgrading.
+
 
 ## Usage
 

--- a/docs/FacebookApp.fbmd
+++ b/docs/FacebookApp.fbmd
@@ -39,13 +39,13 @@ Returns an app access token in the form of an [`AccessToken`](/docs/php/AccessTo
 ~~~~
 public string getId()
 ~~~~
-Returns an the app id.
+Returns the app id.
 
 ## getSecret() {#get-secret}
 ~~~~
 public string getSecret()
 ~~~~
-Returns an the app secret.
+Returns the app secret.
 
 ## Serialization {#serialization}
 


### PR DESCRIPTION
I had to dig through the discussion in #382 before I found a link to @SammyK 's site where I was able to find the upgrade guide for v4.x to v5.x.

This pull request puts a link to the upgrade guide up-front in the Readme!