### PR TITLE
Update SDK version and typo fix in FacebookApp

### DIFF
--- a/docs/FacebookApp.fbmd
+++ b/docs/FacebookApp.fbmd
@@ -39,13 +39,13 @@ Returns an app access token in the form of an [`AccessToken`](/docs/php/AccessTo
 ~~~~
 public string getId()
 ~~~~
-Returns an the app id.
+Returns the app id.
 
 ## getSecret() {#get-secret}
 ~~~~
 public string getSecret()
 ~~~~
-Returns an the app secret.
+Returns the app secret.
 
 ## Serialization {#serialization}
 

--- a/docs/FacebookApp.fbmd
+++ b/docs/FacebookApp.fbmd
@@ -39,13 +39,13 @@ Returns an app access token in the form of an [`AccessToken`](/docs/php/AccessTo
 ~~~~
 public string getId()
 ~~~~
-Returns the app id.
+Returns an the app id.
 
 ## getSecret() {#get-secret}
 ~~~~
 public string getSecret()
 ~~~~
-Returns the app secret.
+Returns an the app secret.
 
 ## Serialization {#serialization}
 

--- a/src/Facebook/Facebook.php
+++ b/src/Facebook/Facebook.php
@@ -59,7 +59,7 @@ class Facebook
     /**
      * @const string Version number of the Facebook PHP SDK.
      */
-    const VERSION = '5.0.0';
+    const VERSION = '5.1.0';
 
     /**
      * @const string Default Graph API version for requests.


### PR DESCRIPTION
-The tag for this release is v5.1.0, but the `VERSION` constant still said `5.0.0`
-There are two typos in the documentation for FacebookApp