### PR TITLE
Check curl extension

### DIFF
--- a/src/Facebook/FacebookClient.php
+++ b/src/Facebook/FacebookClient.php
@@ -124,7 +124,7 @@ class FacebookClient
      */
     public function detectHttpClientHandler()
     {
-        return function_exists('curl_init') ? new FacebookCurlHttpClient() : new FacebookStreamHttpClient();
+        return extension_loaded('curl') ? new FacebookCurlHttpClient() : new FacebookStreamHttpClient();
     }
 
     /**


### PR DESCRIPTION
The `FacebookCurlHttpClient` is using more than the `curl_init` function, so that class could be invoked without problems creating a fake `curl_init`: https://3v4l.org/CjcVS