### PR TITLE
headers type + empty function

### DIFF
--- a/src/Facebook/HttpClients/FacebookStream.php
+++ b/src/Facebook/HttpClients/FacebookStream.php
@@ -41,7 +41,7 @@ class FacebookStream
     /**
      * @var array Response headers from the stream wrapper
      */
-    protected $responseHeaders;
+    protected $responseHeaders = [];
 
     /**
      * Make a new context stream reference instance
@@ -56,7 +56,7 @@ class FacebookStream
     /**
      * The response headers from the stream wrapper
      *
-     * @return array|null
+     * @return array
      */
     public function getResponseHeaders()
     {
@@ -73,7 +73,7 @@ class FacebookStream
     public function fileGetContents($url)
     {
         $rawResponse = file_get_contents($url, false, $this->stream);
-        $this->responseHeaders = $http_response_header;
+        $this->responseHeaders = $http_response_header ?: [];
 
         return $rawResponse;
     }

--- a/src/Facebook/HttpClients/FacebookStreamHttpClient.php
+++ b/src/Facebook/HttpClients/FacebookStreamHttpClient.php
@@ -66,7 +66,7 @@ class FacebookStreamHttpClient implements FacebookHttpClientInterface
         $rawBody = $this->facebookStream->fileGetContents($url);
         $rawHeaders = $this->facebookStream->getResponseHeaders();
 
-        if ($rawBody === false || !$rawHeaders) {
+        if ($rawBody === false || empty($rawHeaders)) {
             throw new FacebookSDKException('Stream returned an empty response', 660);
         }
 

--- a/src/Facebook/Url/FacebookUrlManipulator.php
+++ b/src/Facebook/Url/FacebookUrlManipulator.php
@@ -76,7 +76,7 @@ class FacebookUrlManipulator
      */
     public static function appendParamsToUrl($url, array $newParams = [])
     {
-        if (!$newParams) {
+        if (empty($newParams)) {
             return $url;
         }
 


### PR DESCRIPTION
* single internal type for response headers
* use the empty function instead of implicit casting