### PR TITLE
replaced deprecated method

### DIFF
--- a/src/Facebook/GraphNodes/GraphObjectFactory.php
+++ b/src/Facebook/GraphNodes/GraphObjectFactory.php
@@ -68,7 +68,7 @@ class GraphObjectFactory extends GraphNodeFactory
      */
     public function makeGraphEvent()
     {
-        return $this->makeGraphObject(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphEvent');
+        return $this->makeGraphNode(static::BASE_GRAPH_OBJECT_PREFIX . 'GraphEvent');
     }
 
     /**


### PR DESCRIPTION
The method `makeGraphObject ` is marked as deprecated, so internally shouldn’t be used.