### PR TITLE
Fixed PHPDoc annotations

### DIFF
--- a/src/Facebook/Authentication/OAuth2Client.php
+++ b/src/Facebook/Authentication/OAuth2Client.php
@@ -250,9 +250,9 @@ class OAuth2Client
     /**
      * Send a request to Graph with an app access token.
      *
-     * @param string      $endpoint
-     * @param array       $params
-     * @param string|null $accessToken
+     * @param string                  $endpoint
+     * @param array                   $params
+     * @param AccessToken|string|null $accessToken
      *
      * @return FacebookResponse
      *

--- a/src/Facebook/FileUpload/FacebookResumableUploader.php
+++ b/src/Facebook/FileUpload/FacebookResumableUploader.php
@@ -23,8 +23,9 @@
  */
 namespace Facebook\FileUpload;
 
-use Facebook\Exceptions\FacebookResumableUploadException;
+use Facebook\Authentication\AccessToken;
 use Facebook\Exceptions\FacebookResponseException;
+use Facebook\Exceptions\FacebookResumableUploadException;
 use Facebook\Exceptions\FacebookSDKException;
 use Facebook\FacebookApp;
 use Facebook\FacebookClient;
@@ -58,10 +59,10 @@ class FacebookResumableUploader
     protected $graphVersion;
 
     /**
-     * @param FacebookApp $app
-     * @param FacebookClient $client
-     * @param string $accessToken
-     * @param string $graphVersion
+     * @param FacebookApp             $app
+     * @param FacebookClient          $client
+     * @param AccessToken|string|null $accessToken
+     * @param string                  $graphVersion
      */
     public function __construct(FacebookApp $app, FacebookClient $client, $accessToken, $graphVersion)
     {


### PR DESCRIPTION
`Facebook\Authentication\AccessToken` is accepted by both `Facebook\Authentication\OAuth2Client` and `Facebook\FileUpload\FacebookResumableUploader` because implements the `__toString` method, but it wasn't added in the PHPDoc annotations.