### PR TITLE
[Bugfix] Facebook AccessToken is being validated correctly

### DIFF
--- a/src/Facebook/FacebookClient.php
+++ b/src/Facebook/FacebookClient.php
@@ -197,7 +197,7 @@ class FacebookClient
      */
     public function sendRequest(FacebookRequest $request)
     {
-        if (get_class($request) === 'FacebookRequest') {
+        if (get_class($request) === 'Facebook\FacebookRequest') {
             $request->validateAccessToken();
         }
 

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -218,8 +218,8 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('multipart/form-data; boundary=', $headersSent['Content-Type']);
     }
 
-    public function testAFacebookRequestValidateAccessTokenIsNotProvided(){
-
+    public function testAFacebookRequestValidatesTheAccessTokenWhenOneIsNotProvided()
+    {
         $this->setExpectedException('Facebook\Exceptions\FacebookSDKException');
 
         $fbRequest = new FacebookRequest($this->fbApp, null, 'GET', '/foo');

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -218,6 +218,14 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('multipart/form-data; boundary=', $headersSent['Content-Type']);
     }
 
+    public function testAFacebookRequestValidateAccessTokenIsNotProvided(){
+
+        $this->setExpectedException('Facebook\Exceptions\FacebookSDKException');
+
+        $fbRequest = new FacebookRequest($this->fbApp, null, 'GET', '/foo');
+        $this->fbClient->sendRequest($fbRequest);
+    }
+
     /**
      * @group integration
      */


### PR DESCRIPTION
That commit fixes the access token validation bug, when access token is not being validated at all.   