### PR TITLE
fix use of exception class

### DIFF
--- a/src/Facebook/HttpClients/HttpClientsFactory.php
+++ b/src/Facebook/HttpClients/HttpClientsFactory.php
@@ -25,6 +25,7 @@ namespace Facebook\HttpClients;
 
 use GuzzleHttp\Client;
 use InvalidArgumentException;
+use Exception;
 
 class HttpClientsFactory
 {


### PR DESCRIPTION
Trying to initialize with `http_client_handler` set to `guzzle` without having Guzzle available (or `curl` without cURL) would result in a fatal error because there is no `Facebook\HttpClients\Exception` class:
```
PHP Fatal error:  Class 'Facebook\HttpClients\Exception' not found in ..../vendor/facebook/php-sdk-v4/src/Facebook/HttpClients/HttpClientsFactory.php on line 68
```

So I'd figure it should be a generic `Exception`.
