### PR TITLE
Added version number (v5) to headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Facebook SDK for PHP
+# Facebook SDK for PHP (v5)
 
 [![Build Status](https://img.shields.io/travis/facebook/facebook-php-sdk-v4/master.svg)](https://travis-ci.org/facebook/facebook-php-sdk-v4)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/facebook/facebook-php-sdk-v4/?branch=master)


### PR DESCRIPTION
We received a report that people are confused by the repo name. `facebook-php-sdk-v4` indicates that the repo is for v4, not v5 or other versions.
To make clear that people can find v5 in this repo the latest version number should be part of the headline.