### PR TITLE
GitHub Issue #546: Received a fatal because mb_substr was not found.

### DIFF
--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
@@ -48,11 +48,15 @@ trait PseudoRandomStringGeneratorTrait
      *
      * @param string $binaryData The binary data to convert to hex.
      * @param int    $length     The length of the string to return.
+     * @throws \RuntimeException Throws an exception when multibyte support is not enabled
      *
      * @return string
      */
     public function binToHex($binaryData, $length)
     {
-        return mb_substr(bin2hex($binaryData), 0, $length);
+        if(true !== extension_loaded('mbstring')) { 
+            throw new \RuntimeException('Multibyte support required'); 
+        }
+        return \mb_substr(\bin2hex($binaryData), 0, $length);
     }
 }

--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
@@ -54,8 +54,8 @@ trait PseudoRandomStringGeneratorTrait
      */
     public function binToHex($binaryData, $length)
     {
-        if(true !== extension_loaded('mbstring')) { 
-            throw new \RuntimeException('Multibyte support required'); 
+        if (true !== extension_loaded('mbstring')) {
+            throw new \RuntimeException('Multibyte support required');
         }
         return \mb_substr(\bin2hex($binaryData), 0, $length);
     }


### PR DESCRIPTION
Added logic to wrap the extension missing fatal error and ensured the mb_filter function is taken from PHP base namespace and not from the FB SDK namespace.

Test running and succeeded:
```
PHPUnit 4.8.21 by Sebastian Bergmann and contributors.

...............................................................  63 / 267 ( 23%)
............................................................... 126 / 267 ( 47%)
............................................................... 189 / 267 ( 70%)
............................................................... 252 / 267 ( 94%)
...............

Time: 6.36 seconds, Memory: 12.00Mb

OK (267 tests, 614 assertions)
```