### PR TITLE
Remove mb-string dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "ext-mbstring": "*"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
@@ -26,7 +25,8 @@
     "autoload": {
         "psr-4": {
             "Facebook\\": "src/Facebook/"
-        }
+        },
+        "files": ["src/Facebook/polyfills.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -235,27 +235,19 @@ class FacebookRedirectLoginHelper
     protected function validateCsrf()
     {
         $state = $this->getState();
+        if (!$state) {
+            throw new FacebookSDKException('Cross-site request forgery validation failed. Required GET param "state" missing.');
+        }
         $savedState = $this->persistentDataHandler->get('state');
-
-        if (!$state || !$savedState) {
-            throw new FacebookSDKException('Cross-site request forgery validation failed. Required param "state" missing.');
+        if (!$savedState) {
+            throw new FacebookSDKException('Cross-site request forgery validation failed. Required param "state" missing from persistent data.');
         }
 
-        $savedLen = strlen($savedState);
-        $givenLen = strlen($state);
-
-        if ($savedLen !== $givenLen) {
-            throw new FacebookSDKException('Cross-site request forgery validation failed. The "state" param from the URL and session do not match.');
+        if (\hash_equals($savedState, $state)) {
+            return;
         }
 
-        $result = 0;
-        for ($i = 0; $i < $savedLen; $i++) {
-            $result |= ord($state[$i]) ^ ord($savedState[$i]);
-        }
-
-        if ($result !== 0) {
-            throw new FacebookSDKException('Cross-site request forgery validation failed. The "state" param from the URL and session do not match.');
-        }
+        throw new FacebookSDKException('Cross-site request forgery validation failed. The "state" param from the URL and session do not match.');
     }
 
     /**

--- a/src/Facebook/SignedRequest.php
+++ b/src/Facebook/SignedRequest.php
@@ -268,14 +268,8 @@ class SignedRequest
      */
     protected function validateSignature($hashedSig, $sig)
     {
-        if (mb_strlen($hashedSig) === mb_strlen($sig)) {
-            $validate = 0;
-            for ($i = 0; $i < mb_strlen($sig); $i++) {
-                $validate |= ord($hashedSig[$i]) ^ ord($sig[$i]);
-            }
-            if ($validate === 0) {
-                return;
-            }
+        if (\hash_equals($hashedSig, $sig)) {
+            return;
         }
 
         throw new FacebookSDKException('Signed request has an invalid signature.', 602);

--- a/src/Facebook/polyfills.php
+++ b/src/Facebook/polyfills.php
@@ -23,21 +23,22 @@
  */
 
 /**
- * @see http://php.net/manual/en/function.hash-equals.php#115635
+ * @see https://github.com/sarciszewski/php-future/blob/master/src/Security.php#L37-L51
  */
 if(!function_exists('hash_equals')) {
-    function hash_equals($str1, $str2)
+    function hash_equals($knownString, $userString)
     {
-        if(strlen($str1) != strlen($str2)) {
+        $kLen = strlen($knownString);
+        $uLen = strlen($userString);
+        if ($kLen !== $uLen) {
             return false;
         }
-
-        $res = $str1 ^ $str2;
-        $ret = 0;
-        for($i = strlen($res) - 1; $i >= 0; $i--) {
-            $ret |= ord($res[$i]);
+        $result = 0;
+        for ($i = 0; $i < $kLen; $i++) {
+            $result |= (ord($knownString[$i]) ^ ord($userString[$i]));
         }
 
-        return !$ret;
+        // They are only identical strings if $result is exactly 0...
+        return 0 === $result;
     }
 }

--- a/src/Facebook/polyfills.php
+++ b/src/Facebook/polyfills.php
@@ -25,7 +25,7 @@
 /**
  * @see https://github.com/sarciszewski/php-future/blob/master/src/Security.php#L37-L51
  */
-if(!function_exists('hash_equals')) {
+if (!function_exists('hash_equals')) {
     function hash_equals($knownString, $userString)
     {
         if (function_exists('mb_strlen')) {

--- a/src/Facebook/polyfills.php
+++ b/src/Facebook/polyfills.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2014 Facebook, Inc.
+ * Copyright 2016 Facebook, Inc.
  *
  * You are hereby granted a non-exclusive, worldwide, royalty-free license to
  * use, copy, modify, and distribute this software in source code or binary
@@ -21,39 +21,23 @@
  * DEALINGS IN THE SOFTWARE.
  *
  */
-namespace Facebook\PseudoRandomString;
 
-trait PseudoRandomStringGeneratorTrait
-{
-    /**
-     * Validates the length argument of a random string.
-     *
-     * @param int $length The length to validate.
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function validateLength($length)
+/**
+ * @see http://php.net/manual/en/function.hash-equals.php#115635
+ */
+if(!function_exists('hash_equals')) {
+    function hash_equals($str1, $str2)
     {
-        if (!is_int($length)) {
-            throw new \InvalidArgumentException('getPseudoRandomString() expects an integer for the string length');
+        if(strlen($str1) != strlen($str2)) {
+            return false;
         }
 
-        if ($length < 1) {
-            throw new \InvalidArgumentException('getPseudoRandomString() expects a length greater than 1');
+        $res = $str1 ^ $str2;
+        $ret = 0;
+        for($i = strlen($res) - 1; $i >= 0; $i--) {
+            $ret |= ord($res[$i]);
         }
-    }
 
-    /**
-     * Converts binary data to hexadecimal of arbitrary length.
-     *
-     * @param string $binaryData The binary data to convert to hex.
-     * @param int    $length     The length of the string to return.
-     * @throws \RuntimeException Throws an exception when multibyte support is not enabled
-     *
-     * @return string
-     */
-    public function binToHex($binaryData, $length)
-    {
-        return \substr(\bin2hex($binaryData), 0, $length);
+        return !$ret;
     }
 }

--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -120,6 +120,9 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 
     public function testCurlHttpClientHandlerCanBeForced()
     {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('cURL must be installed to test cURL client handler.');
+        }
         $config = array_merge($this->config, [
             'http_client_handler' => 'curl'
         ]);

--- a/tests/HttpClients/FacebookCurlHttpClientTest.php
+++ b/tests/HttpClients/FacebookCurlHttpClientTest.php
@@ -43,6 +43,9 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
 
     public function setUp()
     {
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped('cURL must be installed to test cURL client handler.');
+        }
         $this->curlMock = m::mock('Facebook\HttpClients\FacebookCurl');
         $this->curlClient = new FacebookCurlHttpClient($this->curlMock);
     }

--- a/tests/HttpClients/FacebookCurlHttpClientTest.php
+++ b/tests/HttpClients/FacebookCurlHttpClientTest.php
@@ -147,15 +147,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
     public function testIsolatesTheHeaderAndBody()
     {
         $this->curlMock
-            ->shouldReceive('getinfo')
-            ->with(CURLINFO_HEADER_SIZE)
-            ->once()
-            ->andReturn(strlen($this->fakeRawHeader));
-        $this->curlMock
-            ->shouldReceive('version')
-            ->once()
-            ->andReturn(['version_number' => self::CURL_VERSION_STABLE]);
-        $this->curlMock
             ->shouldReceive('exec')
             ->once()
             ->andReturn($this->fakeRawHeader . $this->fakeRawBody);
@@ -170,15 +161,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
     public function testProperlyHandlesProxyHeaders()
     {
         $rawHeader = $this->fakeRawProxyHeader . $this->fakeRawHeader;
-        $this->curlMock
-            ->shouldReceive('getinfo')
-            ->with(CURLINFO_HEADER_SIZE)
-            ->once()
-            ->andReturn(mb_strlen($rawHeader));
-        $this->curlMock
-            ->shouldReceive('version')
-            ->once()
-            ->andReturn(['version_number' => self::CURL_VERSION_STABLE]);
         $this->curlMock
             ->shouldReceive('exec')
             ->once()
@@ -195,15 +177,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
     {
         $rawHeader = $this->fakeRawProxyHeader . $this->fakeRawHeader;
         $this->curlMock
-            ->shouldReceive('getinfo')
-            ->with(CURLINFO_HEADER_SIZE)
-            ->once()
-            ->andReturn(mb_strlen($this->fakeRawHeader)); // Mimic bug that doesn't count proxy header
-        $this->curlMock
-            ->shouldReceive('version')
-            ->once()
-            ->andReturn(['version_number' => self::CURL_VERSION_BUGGY]);
-        $this->curlMock
             ->shouldReceive('exec')
             ->once()
             ->andReturn($rawHeader . $this->fakeRawBody);
@@ -219,15 +192,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
     {
         $rawHeader = $this->fakeRawProxyHeader2 . $this->fakeRawHeader;
         $this->curlMock
-            ->shouldReceive('getinfo')
-            ->with(CURLINFO_HEADER_SIZE)
-            ->once()
-            ->andReturn(mb_strlen($this->fakeRawHeader)); // Mimic bug that doesn't count proxy header
-        $this->curlMock
-            ->shouldReceive('version')
-            ->once()
-            ->andReturn(['version_number' => self::CURL_VERSION_BUGGY]);
-        $this->curlMock
             ->shouldReceive('exec')
             ->once()
             ->andReturn($rawHeader . $this->fakeRawBody);
@@ -242,15 +206,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
     public function testProperlyHandlesRedirectHeaders()
     {
         $rawHeader = $this->fakeRawRedirectHeader . $this->fakeRawHeader;
-        $this->curlMock
-            ->shouldReceive('getinfo')
-            ->with(CURLINFO_HEADER_SIZE)
-            ->once()
-            ->andReturn(mb_strlen($rawHeader));
-        $this->curlMock
-            ->shouldReceive('version')
-            ->once()
-            ->andReturn(['version_number' => self::CURL_VERSION_STABLE]);
         $this->curlMock
             ->shouldReceive('exec')
             ->once()
@@ -281,15 +236,6 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
             ->shouldReceive('errno')
             ->once()
             ->andReturn(null);
-        $this->curlMock
-            ->shouldReceive('getinfo')
-            ->with(CURLINFO_HEADER_SIZE)
-            ->once()
-            ->andReturn(mb_strlen($this->fakeRawHeader));
-        $this->curlMock
-            ->shouldReceive('version')
-            ->once()
-            ->andReturn(['version_number' => self::CURL_VERSION_STABLE]);
         $this->curlMock
             ->shouldReceive('close')
             ->once()

--- a/tests/HttpClients/HttpClientsFactoryTest.php
+++ b/tests/HttpClients/HttpClientsFactoryTest.php
@@ -54,15 +54,19 @@ class HttpClientsFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function httpClientsProvider()
     {
-        return [
-            ['curl', self::COMMON_NAMESPACE . 'FacebookCurlHttpClient'],
-            ['guzzle', self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
-            ['stream', self::COMMON_NAMESPACE . 'FacebookStreamHttpClient'],
-            [new Client(), self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
-            [new FacebookCurlHttpClient(), self::COMMON_NAMESPACE . 'FacebookCurlHttpClient'],
-            [new FacebookGuzzleHttpClient(), self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
-            [new FacebookStreamHttpClient(), self::COMMON_NAMESPACE . 'FacebookStreamHttpClient'],
-            [null, self::COMMON_INTERFACE],
+        $clients = [
+          ['guzzle', self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
+          ['stream', self::COMMON_NAMESPACE . 'FacebookStreamHttpClient'],
+          [new Client(), self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
+          [new FacebookGuzzleHttpClient(), self::COMMON_NAMESPACE . 'FacebookGuzzleHttpClient'],
+          [new FacebookStreamHttpClient(), self::COMMON_NAMESPACE . 'FacebookStreamHttpClient'],
+          [null, self::COMMON_INTERFACE],
         ];
+        if (extension_loaded('curl')) {
+            $clients[] = ['curl', self::COMMON_NAMESPACE . 'FacebookCurlHttpClient'];
+            $clients[] = [new FacebookCurlHttpClient(), self::COMMON_NAMESPACE . 'FacebookCurlHttpClient'];
+        }
+
+        return $clients;
     }
 }

--- a/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
+++ b/tests/PseudoRandomString/PseudoRandomStringFactoryTest.php
@@ -53,11 +53,19 @@ class PseudoRandomStringFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function httpClientsProvider()
     {
-        return [
-            ['mcrypt', self::COMMON_NAMESPACE . 'McryptPseudoRandomStringGenerator'],
-            ['openssl', self::COMMON_NAMESPACE . 'OpenSslPseudoRandomStringGenerator'],
-            ['urandom', self::COMMON_NAMESPACE . 'UrandomPseudoRandomStringGenerator'],
-            [null, self::COMMON_INTERFACE],
+        $providers = [
+          [null, self::COMMON_INTERFACE],
         ];
+        if (function_exists('mcrypt_create_iv')) {
+            $providers[] = ['mcrypt', self::COMMON_NAMESPACE . 'McryptPseudoRandomStringGenerator'];
+        }
+        if (function_exists('openssl_random_pseudo_bytes')) {
+            $providers[] = ['openssl', self::COMMON_NAMESPACE . 'OpenSslPseudoRandomStringGenerator'];
+        }
+        if (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
+            $providers[] = ['urandom', self::COMMON_NAMESPACE . 'UrandomPseudoRandomStringGenerator'];
+        }
+
+        return $providers;
     }
 }


### PR DESCRIPTION
Re #546

This kills the unnecessary mb-string dependency. In doing so I was able to rip out quite a bit of code & tests related to the overly-complicated cURL client implementation. While ripping out mb-string for signed request signature validation, I made a polyfill for the [`hash_equals()` function](http://php.net/manual/en/function.hash-equals.php) in PHP 5.6 *(which has been [vetted by infosec nerds](https://twitter.com/SammyK/status/697179032983482368))*. This allowed me to removed the duplicate code for comparing the CSRF token for redirect logins as well as signed request signature validations.

Also - the tests were failing out of the box when mcrypt, openssl or curl weren't installed. I fixed all that. :)

Make sure to `composer dump-autoload` before reviewing this one. :)