### PR TITLE
Use Composer safe versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,3 @@ install:
 script:
   - vendor/bin/phpcs src --standard=psr2 -spn
   - vendor/bin/phpunit --coverage-text --exclude-group integration
-
-matrix:
-  allow_failures:
-    - php: 7.0
-  fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": "^5.4|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
The range operator isn't considered "safe" by Composer ([ref](https://getcomposer.org/doc/articles/versions.md#range)), so a switch to the caret operator is suggested.

Also the PHP 7 build ends with success, so imo it should be kept as a requirement also on TravisCI.