### PR TITLE
Add better error checking for app IDs as int when greater than PHP_INT_MAX

### DIFF
--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -24,6 +24,7 @@
 namespace Facebook;
 
 use Facebook\Authentication\AccessToken;
+use Facebook\Exceptions\FacebookSDKException;
 
 class FacebookApp implements \Serializable
 {
@@ -40,10 +41,18 @@ class FacebookApp implements \Serializable
     /**
      * @param string $id
      * @param string $secret
+     *
+     * @throws FacebookSDKException
      */
     public function __construct($id, $secret)
     {
-        $this->id = $id;
+        if (!is_string($id)
+          // Keeping this for BC. Integers greater than PHP_INT_MAX will make is_int() return false
+          && !is_int($id)) {
+            throw new FacebookSDKException('The "app_id" must be formatted as a string since many app ID\'s are greater than PHP_INT_MAX on some systems.');
+        }
+        // We cast as a string in case a valid int was set on a 64-bit system and this is unserialised on a 32-bit system
+        $this->id = (string) $id;
         $this->secret = $secret;
     }
 

--- a/tests/FacebookAppTest.php
+++ b/tests/FacebookAppTest.php
@@ -63,4 +63,19 @@ class FacebookAppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('id', $newApp->getId());
         $this->assertEquals('secret', $newApp->getSecret());
     }
+
+    /**
+     * @expectedException \Facebook\Exceptions\FacebookSDKException
+     */
+    public function testOverflowIntegersWillThrow()
+    {
+        new FacebookApp(PHP_INT_MAX + 1, "foo");
+    }
+
+    public function testUnserializedIdsWillBeString()
+    {
+        $newApp = unserialize(serialize(new FacebookApp(1, "foo")));
+
+        $this->assertSame('1', $newApp->getId());
+    }
 }


### PR DESCRIPTION
Fixes #532 

Facebook app ID's are really big and on 32-bit systems many are bigger than `PHP_INT_MAX` causing integer overflow issues. We can't fix when people overflow an int:

```php
$appId = PHP_INT_MAX + 10;
```

But we can at least give them better error messages and prevent overflows when `FacebookApp` is unserialized. :)