### PR TITLE
Making sure that AccessToken::__toString returns string

### DIFF
--- a/src/Facebook/Entities/AccessToken.php
+++ b/src/Facebook/Entities/AccessToken.php
@@ -65,7 +65,7 @@ class AccessToken
    */
   public function __construct($accessToken, $expiresAt = 0, $machineId = null)
   {
-    $this->accessToken = $accessToken;
+    $this->accessToken = (string) $accessToken;
     if ($expiresAt) {
       $this->setExpiresAtFromTimeStamp($expiresAt);
     }


### PR DESCRIPTION
To avoid issue like: "Catchable Fatal Error: Method Facebook\Entities\AccessToken::__toString() must return a string value"