### PR TITLE
Avoids using unserialize to prevent Object Injection security issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ Starting with version 5, the Facebook PHP SDK follows [SemVer](http://semver.org
 ## 5.0.x
 
 Version 5 of the Facebook PHP SDK is a complete refactor of version 4. It comes loaded with lots of new features and a friendlier API.
-
+- 5.1.4
+  - Breaking changes
+    - Changes the serialization method of FacebookApp
+      - FacebookApps serialized by versions prior 5.1.4 cannot be unserialized by this version
 - 5.0 (2015-??-??)
   - New features
     - Added the `Facebook\Facebook` super service for an easier API
@@ -22,8 +25,8 @@ Version 5 of the Facebook PHP SDK is a complete refactor of version 4. It comes 
       - Many improvements to the Graph node subtypes
     - New injectable interfaces
       - Added a `PersistentDataInterface` for custom persistent data handling
-      - Added a `PseudoRandomStringGeneratorInterface` for customizable CSPRNG's 
-      - Added a `UrlDetectionInterface` for custom URL-detection logic 
+      - Added a `PseudoRandomStringGeneratorInterface` for customizable CSPRNG's
+      - Added a `UrlDetectionInterface` for custom URL-detection logic
   - Codebase changes
     - Moved exception classes to `Exception\*` directory
     - Moved response collection objects to `GraphNodes\*` directory

--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -84,7 +84,7 @@ class FacebookApp implements \Serializable
      */
     public function serialize()
     {
-        return serialize([$this->id, $this->secret]);
+        return json_encode([$this->id, $this->secret]);
     }
 
     /**
@@ -94,7 +94,7 @@ class FacebookApp implements \Serializable
      */
     public function unserialize($serialized)
     {
-        list($id, $secret) = unserialize($serialized);
+        list($id, $secret) = json_decode($serialized);
 
         $this->__construct($id, $secret);
     }

--- a/src/Facebook/FacebookApp.php
+++ b/src/Facebook/FacebookApp.php
@@ -84,7 +84,7 @@ class FacebookApp implements \Serializable
      */
     public function serialize()
     {
-        return json_encode([$this->id, $this->secret]);
+        return implode('|', [$this->id, $this->secret]);
     }
 
     /**
@@ -94,7 +94,7 @@ class FacebookApp implements \Serializable
      */
     public function unserialize($serialized)
     {
-        list($id, $secret) = json_decode($serialized);
+        list($id, $secret) = explode('|', $serialized);
 
         $this->__construct($id, $secret);
     }


### PR DESCRIPTION
Rewrites the serialization methods to use json_encode / json_decode to prevent Object Injection attacks.

See more: https://www.owasp.org/index.php/PHP_Object_Injection

This is also a request from WordPress to allow the SDK to be used in plugins on WordPress.com and WordPress VIP:

https://vip.wordpress.com/documentation/code-review-what-we-look-for/#serializing-data