### PR TITLE
Fix: Reduce visibility of setUp()

### DIFF
--- a/tests/Authentication/OAuth2ClientTest.php
+++ b/tests/Authentication/OAuth2ClientTest.php
@@ -46,7 +46,7 @@ class OAuth2ClientTest extends \PHPUnit_Framework_TestCase
      */
     protected $oauth;
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_secret');
         $this->client = new FooFacebookClientForOAuth2Test();

--- a/tests/Exceptions/FacebookResponseExceptionTest.php
+++ b/tests/Exceptions/FacebookResponseExceptionTest.php
@@ -36,7 +36,7 @@ class FacebookResponseExceptionTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->request = new FacebookRequest(new FacebookApp('123', 'foo'));
     }

--- a/tests/FacebookAppTest.php
+++ b/tests/FacebookAppTest.php
@@ -32,7 +32,7 @@ class FacebookAppTest extends \PHPUnit_Framework_TestCase
      */
     private $app;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->app = new FacebookApp('id', 'secret');
     }

--- a/tests/FacebookBatchRequestTest.php
+++ b/tests/FacebookBatchRequestTest.php
@@ -36,7 +36,7 @@ class FacebookBatchRequestTest extends \PHPUnit_Framework_TestCase
      */
     private $app;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->app = new FacebookApp('123', 'foo_secret');
     }

--- a/tests/FacebookBatchResponseTest.php
+++ b/tests/FacebookBatchResponseTest.php
@@ -41,7 +41,7 @@ class FacebookBatchResponseTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->app = new FacebookApp('123', 'foo_secret');
         $this->request = new FacebookRequest(

--- a/tests/FacebookClientTest.php
+++ b/tests/FacebookClientTest.php
@@ -82,7 +82,7 @@ class FacebookClientTest extends \PHPUnit_Framework_TestCase
      */
     public static $testFacebookClient;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->fbApp = new FacebookApp('id', 'shhhh!');
         $this->fbClient = new FacebookClient(new MyFooClientHandler());

--- a/tests/FacebookResponseTest.php
+++ b/tests/FacebookResponseTest.php
@@ -34,7 +34,7 @@ class FacebookResponseTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_secret');
         $this->request = new FacebookRequest(

--- a/tests/FileUpload/FacebookFileTest.php
+++ b/tests/FileUpload/FacebookFileTest.php
@@ -29,7 +29,7 @@ class FacebookFileTest extends \PHPUnit_Framework_TestCase
 {
     protected $testFile = '';
 
-    public function setUp()
+    protected function setUp()
     {
         $this->testFile = __DIR__ . '/../foo.txt';
     }

--- a/tests/FileUpload/FacebookResumableUploaderTest.php
+++ b/tests/FileUpload/FacebookResumableUploaderTest.php
@@ -53,7 +53,7 @@ class FacebookResumableUploaderTest extends \PHPUnit_Framework_TestCase
      */
     private $file;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->fbApp = new FacebookApp('app_id', 'app_secret');
         $this->graphApi = new FakeGraphApiForResumableUpload();

--- a/tests/GraphNodes/AbstractGraphNode.php
+++ b/tests/GraphNodes/AbstractGraphNode.php
@@ -33,7 +33,7 @@ abstract class AbstractGraphNode extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         $this->responseMock = m::mock('\Facebook\FacebookResponse');

--- a/tests/GraphNodes/GraphAlbumTest.php
+++ b/tests/GraphNodes/GraphAlbumTest.php
@@ -34,7 +34,7 @@ class GraphAlbumTest extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
     }

--- a/tests/GraphNodes/GraphEdgeTest.php
+++ b/tests/GraphNodes/GraphEdgeTest.php
@@ -40,7 +40,7 @@ class GraphEdgeTest extends \PHPUnit_Framework_TestCase
         'previous' => 'https://graph.facebook.com/v7.12/998899/photos?pretty=0&limit=25&before=foo_before_cursor',
     ];
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_app_secret');
         $this->request = new FacebookRequest(

--- a/tests/GraphNodes/GraphEventTest.php
+++ b/tests/GraphNodes/GraphEventTest.php
@@ -34,7 +34,7 @@ class GraphEventTest extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->responseMock = m::mock('\Facebook\FacebookResponse');
     }

--- a/tests/GraphNodes/GraphGroupTest.php
+++ b/tests/GraphNodes/GraphGroupTest.php
@@ -34,7 +34,7 @@ class GraphGroupTest extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->responseMock = m::mock('\Facebook\FacebookResponse');
     }

--- a/tests/GraphNodes/GraphNodeFactoryTest.php
+++ b/tests/GraphNodes/GraphNodeFactoryTest.php
@@ -47,7 +47,7 @@ class GraphNodeFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_app_secret');
         $this->request = new FacebookRequest(

--- a/tests/GraphNodes/GraphObjectFactoryTest.php
+++ b/tests/GraphNodes/GraphObjectFactoryTest.php
@@ -38,7 +38,7 @@ class GraphObjectFactoryTest extends \PHPUnit_Framework_TestCase
      */
     protected $request;
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_app_secret');
         $this->request = new FacebookRequest(

--- a/tests/GraphNodes/GraphPageTest.php
+++ b/tests/GraphNodes/GraphPageTest.php
@@ -33,7 +33,7 @@ class GraphPageTest extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
     }

--- a/tests/GraphNodes/GraphSessionInfoTest.php
+++ b/tests/GraphNodes/GraphSessionInfoTest.php
@@ -33,7 +33,7 @@ class GraphSessionInfoTest extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
     }

--- a/tests/GraphNodes/GraphUserTest.php
+++ b/tests/GraphNodes/GraphUserTest.php
@@ -34,7 +34,7 @@ class GraphUserTest extends \PHPUnit_Framework_TestCase
      */
     protected $responseMock;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->responseMock = m::mock('\\Facebook\\FacebookResponse');
     }

--- a/tests/Helpers/FacebookCanvasHelperTest.php
+++ b/tests/Helpers/FacebookCanvasHelperTest.php
@@ -36,7 +36,7 @@ class FacebookCanvasHelperTest extends \PHPUnit_Framework_TestCase
      */
     protected $helper;
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_app_secret');
         $this->helper = new FacebookCanvasHelper($app, new FacebookClient());

--- a/tests/Helpers/FacebookRedirectLoginHelperTest.php
+++ b/tests/Helpers/FacebookRedirectLoginHelperTest.php
@@ -61,7 +61,7 @@ class FacebookRedirectLoginHelperTest extends \PHPUnit_Framework_TestCase
 
     const REDIRECT_URL = 'http://invalid.zzz';
 
-    public function setUp()
+    protected function setUp()
     {
         $this->persistentDataHandler = new FacebookMemoryPersistentDataHandler();
 

--- a/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
+++ b/tests/Helpers/FacebookSignedRequestFromInputHelperTest.php
@@ -61,7 +61,7 @@ class FacebookSignedRequestFromInputHelperTest extends \PHPUnit_Framework_TestCa
     public $rawSignedRequestAuthorizedWithCode = 'oBtmZlsFguNQvGRETDYQQu1-PhwcArgbBBEK4urbpRA=.eyJjb2RlIjoiZm9vX2NvZGUiLCJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MTQwNjMxMDc1MiwidXNlcl9pZCI6IjEyMyJ9';
     public $rawSignedRequestUnauthorized = 'KPlyhz-whtYAhHWr15N5TkbS_avz-2rUJFpFkfXKC88=.eyJhbGdvcml0aG0iOiJITUFDLVNIQTI1NiIsImlzc3VlZF9hdCI6MTQwMjU1MTA4Nn0=';
 
-    public function setUp()
+    protected function setUp()
     {
         $app = new FacebookApp('123', 'foo_app_secret');
         $this->helper = new FooSignedRequestHelper($app, new FooSignedRequestHelperFacebookClient());

--- a/tests/HttpClients/FacebookCurlHttpClientTest.php
+++ b/tests/HttpClients/FacebookCurlHttpClientTest.php
@@ -41,7 +41,7 @@ class FacebookCurlHttpClientTest extends AbstractTestHttpClient
     const CURL_VERSION_STABLE = 0x072400;
     const CURL_VERSION_BUGGY = 0x071400;
 
-    public function setUp()
+    protected function setUp()
     {
         if (!extension_loaded('curl')) {
             $this->markTestSkipped('cURL must be installed to test cURL client handler.');

--- a/tests/HttpClients/FacebookGuzzleHttpClientTest.php
+++ b/tests/HttpClients/FacebookGuzzleHttpClientTest.php
@@ -42,7 +42,7 @@ class FacebookGuzzleHttpClientTest extends AbstractTestHttpClient
      */
     protected $guzzleClient;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->guzzleMock = m::mock('GuzzleHttp\Client');
         $this->guzzleClient = new FacebookGuzzleHttpClient($this->guzzleMock);

--- a/tests/HttpClients/FacebookStreamHttpClientTest.php
+++ b/tests/HttpClients/FacebookStreamHttpClientTest.php
@@ -38,7 +38,7 @@ class FacebookStreamHttpClientTest extends AbstractTestHttpClient
      */
     protected $streamClient;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->streamMock = m::mock('Facebook\HttpClients\FacebookStream');
         $this->streamClient = new FacebookStreamHttpClient($this->streamMock);

--- a/tests/SignedRequestTest.php
+++ b/tests/SignedRequestTest.php
@@ -46,7 +46,7 @@ class SignedRequestTest extends \PHPUnit_Framework_TestCase
         'foo' => 'bar',
     ];
 
-    public function setUp()
+    protected function setUp()
     {
         $this->app = new FacebookApp('123', 'foo_app_secret');
     }


### PR DESCRIPTION
This PR

* [x] reduces the visibility of `setUp()` from `public` to `protected`

🙎 This is the visibility as declared on the parent; there's no need to increase it.