### PR TITLE
Fix: Remove unused local variables

### DIFF
--- a/tests/FacebookTest.php
+++ b/tests/FacebookTest.php
@@ -91,7 +91,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $config = [
             'app_secret' => 'foo_secret',
         ];
-        $fb = new Facebook($config);
+        new Facebook($config);
     }
 
     /**
@@ -104,7 +104,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $config = [
             'app_id' => 'foo_id',
         ];
-        $fb = new Facebook($config);
+        new Facebook($config);
     }
 
     /**
@@ -115,7 +115,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $config = array_merge($this->config, [
             'http_client_handler' => 'foo_handler',
         ]);
-        $fb = new Facebook($config);
+        new Facebook($config);
     }
 
     public function testCurlHttpClientHandlerCanBeForced()
@@ -165,7 +165,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $config = array_merge($this->config, [
             'persistent_data_handler' => 'foo_handler',
         ]);
-        $fb = new Facebook($config);
+        new Facebook($config);
     }
 
     public function testPersistentDataHandlerCanBeForced()
@@ -191,7 +191,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $config = array_merge($this->config, [
             'url_detection_handler' => 'foo_handler',
         ]);
-        $fb = new Facebook($config);
+        new Facebook($config);
     }
 
     public function testTheUrlHandlerWillDefaultToTheFacebookImplementation()
@@ -302,7 +302,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $config = array_merge($this->config, [
             'default_access_token' => 123,
         ]);
-        $fb = new Facebook($config);
+        new Facebook($config);
     }
 
     public function testCreatingANewRequestWillDefaultToTheProperConfig()
@@ -413,6 +413,6 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
           'http_client_handler' => $client,
         ]);
         $fb = new Facebook($config);
-        $response = $fb->uploadVideo('4', __DIR__.'/foo.txt', [], 'foo-token', 3);
+        $fb->uploadVideo('4', __DIR__.'/foo.txt', [], 'foo-token', 3);
     }
 }

--- a/tests/FileUpload/FacebookResumableUploaderTest.php
+++ b/tests/FileUpload/FacebookResumableUploaderTest.php
@@ -86,7 +86,7 @@ class FacebookResumableUploaderTest extends \PHPUnit_Framework_TestCase
         $this->graphApi->failOnStart();
         $uploader = new FacebookResumableUploader($this->fbApp, $this->client, 'access_token', 'v2.4');
 
-        $chunk = $uploader->start('/me/videos', $this->file);
+        $uploader->start('/me/videos', $this->file);
     }
 
     public function testFailedResumableTransferWillNotThrowAndReturnSameChunk()

--- a/tests/PersistentData/FacebookSessionPersistentDataHandlerTest.php
+++ b/tests/PersistentData/FacebookSessionPersistentDataHandlerTest.php
@@ -32,7 +32,7 @@ class FacebookSessionPersistentDataHandlerTest extends \PHPUnit_Framework_TestCa
      */
     public function testInactiveSessionsWillThrow()
     {
-        $handler = new FacebookSessionPersistentDataHandler();
+        new FacebookSessionPersistentDataHandler();
     }
 
     public function testCanSetAValue()


### PR DESCRIPTION
This PR

* [x] removes unused local variables in tests

💁 The variables are never actually assigned a value as during the evaluation of the expressions to the right, exceptions are thrown, so they can safely be removed, right?