### PR TITLE
Fix: Attempt to cache dependencies between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,16 @@ php:
 
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - travis_retry composer self-update
 
 install:
   - travis_retry composer require --dev --no-update squizlabs/php_codesniffer
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --prefer-dist --no-interaction
 
 script:
   - vendor/bin/phpcs src --standard=psr2 -spn


### PR DESCRIPTION
This PR

* [x] attempts to cache dependencies installed with `composer` between builds

💁 Ain't nobody got time for that, right?!