### PR TITLE
Corrected phpDoc comment for binToHex

### DIFF
--- a/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
+++ b/src/Facebook/PseudoRandomString/PseudoRandomStringGeneratorTrait.php
@@ -48,7 +48,6 @@ trait PseudoRandomStringGeneratorTrait
      *
      * @param string $binaryData The binary data to convert to hex.
      * @param int    $length     The length of the string to return.
-     * @throws \RuntimeException Throws an exception when multibyte support is not enabled
      *
      * @return string
      */


### PR DESCRIPTION
The method doesn't actually throw \InvalidArgumentException