### PR TITLE
Avoid "Cannot redeclare class"

### DIFF
--- a/src/Facebook/autoload.php
+++ b/src/Facebook/autoload.php
@@ -74,6 +74,6 @@ spl_autoload_register(function ($class) {
 
     // if the file exists, require it
     if (file_exists($file)) {
-        require $file;
+        require_once $file;
     }
 });


### PR DESCRIPTION
I am not very knowledgeable of this SDK, so this may be a stupid idea (tests will show), but if you opt in for require_once instead of require, you can't have the same class file re-required, which is a good thing.