### PR TITLE
Update README.md - PHP version >= 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Upgrading from v4.x? Facebook PHP SDK v5.x introduced breaking changes. Please [
 
 ## Usage
 
-> **Note:** This version of the Facebook SDK for PHP requires PHP 5.4 or greater.
+> **Note:** This version of the Facebook SDK for PHP requires PHP 5.6 or greater.
 
 Simple GET example of a user's profile.
 


### PR DESCRIPTION
In src/Facebook/SignedRequest.php:271 hash_equals function is used, which was added to PHP 5 >= 5.6.0
http://php.net/manual/en/function.hash-equals.php