### PR TITLE
FacebookRedirectLoginHelper - let's not regenerate CSRF token

### DIFF
--- a/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
+++ b/src/Facebook/Helpers/FacebookRedirectLoginHelper.php
@@ -122,7 +122,7 @@ class FacebookRedirectLoginHelper
      */
     private function makeUrl($redirectUrl, array $scope, array $params = [], $separator = '&')
     {
-        $state = $this->pseudoRandomStringGenerator->getPseudoRandomString(static::CSRF_LENGTH);
+        $state = $this->persistentDataHandler->get('state') ?: $this->pseudoRandomStringGenerator->getPseudoRandomString(static::CSRF_LENGTH);
         $this->persistentDataHandler->set('state', $state);
 
         return $this->oAuth2Client->getAuthorizationUrl($redirectUrl, $state, $scope, $params, $separator);


### PR DESCRIPTION
When `FacebookRedirectLoginHelper::getLoginUrl()` is called it should first check if a CSRF token (called `state` in the source code) has already been generated and use the existing one if it has.
Right now any time the method is called, a new CSRF token is generated. That means if the method is called more than once, only the last URL will be working which is a problem.

What if the user opens up a webpage in multiple tabs at once? Then he will only be able to use Facebook login in the last tab. And if you forget to put favicon.ico on your website, then he will only be able to use Facebook login in IE :) (see https://github.com/facebook/facebook-php-sdk-v4/issues/583 for details).

