### PR TITLE
Fixed issue when Notice "Undefined variable: header" occured on PHP 7.0

### DIFF
--- a/src/Facebook/Url/FacebookUrlDetectionHandler.php
+++ b/src/Facebook/Url/FacebookUrlDetectionHandler.php
@@ -95,7 +95,8 @@ class FacebookUrlDetectionHandler implements UrlDetectionInterface
     protected function getHostName()
     {
         // Check for proxy first
-        if ($header = $this->getHeader('X_FORWARDED_HOST') && $this->isValidForwardedHost($header)) {
+        $header = $this->getHeader('X_FORWARDED_HOST');
+        if ($header && $this->isValidForwardedHost($header)) {
             $elements = explode(',', $header);
             $host = $elements[count($elements) - 1];
         } elseif (!$host = $this->getHeader('HOST')) {


### PR DESCRIPTION
Fixed a notice triggered on PHP 7.0+ Notice: Undefined variable: header, stacktraced in in facebook/php-sdk-v4/src/Facebook/Url/FacebookUrlDetectionHandler.php at line 98