### PR TITLE
Add fix for #619

### DIFF
--- a/src/Facebook/FacebookBatchResponse.php
+++ b/src/Facebook/FacebookBatchResponse.php
@@ -98,7 +98,7 @@ class FacebookBatchResponse extends FacebookResponse implements IteratorAggregat
     public function addResponse($key, $response)
     {
         $originalRequestName = isset($this->batchRequest[$key]['name']) ? $this->batchRequest[$key]['name'] : $key;
-        $originalRequest = isset($this->batchRequest[$key]['request']) ? $this->batchRequest[$key]['request'] : null;
+        $originalRequest = isset($this->batchRequest[$key]['request']) ? $this->batchRequest[$key]['request'] : new FacebookRequest;
 
         $httpResponseBody = isset($response['body']) ? $response['body'] : null;
         $httpResponseCode = isset($response['code']) ? $response['code'] : null;


### PR DESCRIPTION
I've tried my darnedest to replicate the issue in #619, but I can't replicate it for the life of me. I was thinking it was because of timeouts where the response will be `null`, but it handles `null` responses just fine.

I'm thinking this has to be an extreme edge case. At any rate, I added this little patch to keep error messages from being generated if the edge case happens again.

@yguedidi - what do you think? :)